### PR TITLE
feat: split evaluation workflow + add benchmark framework

### DIFF
--- a/.agent/PROJECT_CONTEXT.md
+++ b/.agent/PROJECT_CONTEXT.md
@@ -25,12 +25,14 @@ A **markdown-based CV generator** using Jekyll static site generator, deployed v
 cv/
 ├── .agent/
 │   ├── references/
+│   │   ├── benchmark-testing-framework.md # Standardized workflow benchmarking
 │   │   ├── cv-construction-guide.md   # CV writing best practices & ATS tips
 │   │   └── cv-evaluation-framework.md # 6-category scoring framework
 │   ├── workflows/
 │   │   ├── add-cv-section.md          # Add content to index.md
 │   │   ├── build-cv-wizard.md         # Build CV from data sources
-│   │   ├── evaluate-cv.md             # Evaluate CV with scoring
+│   │   ├── evaluate-cv-quick.md       # Quick CV evaluation (~2-4K tokens)
+│   │   ├── evaluate-cv-deepdive.md    # Deep dive evaluation (~8-15K tokens)
 │   │   ├── generate-template.md       # Create CSS templates
 │   │   └── git-branch-pr.md           # Branch & PR workflow
 │   ├── PROJECT_CONTEXT.md
@@ -394,19 +396,49 @@ The profile contains valuable information that can be extracted:
 
 ---
 
-### 5. CV Evaluation
-**Command:** `/evaluate-cv`  
-**Purpose:** Evaluate and critique CV with scored analysis and optional web dashboard
+### 5. CV Evaluation (Two Variants)
+
+#### Quick Mode
+**Command:** `/evaluate-cv-quick`  
+**Token cost:** ~2K-4K output tokens  
+**Purpose:** Fast, lightweight CV evaluation for iteration cycles
 
 **Features:**
 - 6-category scoring framework (Content, Structure, Impact, ATS, Relevance, Presentation)
 - Dual output: narrative analysis + score card
 - Optional job-targeted evaluation with keyword matching
 - Optional interactive HTML dashboard (neo-brutalism theme)
-- Section-specific or full CV evaluation
 - References `.agent/references/cv-evaluation-framework.md` for scoring rubric
 
+#### Deep Dive Mode
+**Command:** `/evaluate-cv-deepdive`  
+**Token cost:** ~8K-15K output tokens  
+**Purpose:** Comprehensive, evidence-based evaluation with 10 mandatory insight quality standards
+
+**Everything in Quick mode, plus:**
+- Positioning Diagnosis (one-line gap framing)
+- Career Arc Analysis (trajectory mapping)
+- Evidence-based citations (every claim references specific CV content)
+- Actionable rewrite examples (every suggestion includes replacement text)
+- Score impact estimates (numerical improvement predictions)
+- Contradiction detection (inconsistencies between sections)
+- Top 3 high-impact actions with combined score projection
+- ≥80% specificity guarantee (self-checked before output)
+
 **Dashboard Output:** `docs/evaluation/` directory
+
+---
+
+### 6. Benchmark Testing Framework
+**Reference:** `.agent/references/benchmark-testing-framework.md`  
+**Purpose:** Standardized procedure for comparing workflow performance
+
+**When to use:**
+- Enhancing or refactoring an existing workflow
+- Comparing two workflow approaches
+- Validating that changes improve output quality
+
+**Provides:** Methodology, metrics templates, Quality Index formula, execution protocol, trade-off analysis framework, and decision criteria for adopting changes.
 
 ---
 

--- a/.agent/QUICK_REFERENCE.md
+++ b/.agent/QUICK_REFERENCE.md
@@ -116,7 +116,8 @@ git push origin feat/my-feature
 
 - `/add-cv-section` - Add content to index.md
 - `/build-cv-wizard` - Build CV from data sources
-- `/evaluate-cv` - Evaluate CV with scoring & dashboard
+- `/evaluate-cv-quick` - Quick CV evaluation (~2-4K tokens)
+- `/evaluate-cv-deepdive` - Deep dive evaluation (~8-15K tokens)
 - `/generate-template` - Create new CSS template
 - `/git-branch-pr` - Branch & PR workflow
 

--- a/.agent/README.md
+++ b/.agent/README.md
@@ -8,11 +8,13 @@ This directory contains AI agent configurations, workflows, and project context 
 .agent/
 ├── references/
 │   ├── cv-construction-guide.md     # CV writing best practices & ATS tips
-│   └── cv-evaluation-framework.md   # 6-category scoring framework
+│   ├── cv-evaluation-framework.md   # 6-category scoring framework
+│   └── benchmark-testing-framework.md # Workflow benchmarking standard
 ├── workflows/
 │   ├── add-cv-section.md            # Workflow: Update index.md with new sections
 │   ├── build-cv-wizard.md           # Workflow: Build CV from data sources
-│   ├── evaluate-cv.md               # Workflow: Evaluate CV with scoring
+│   ├── evaluate-cv-quick.md         # Workflow: Quick CV evaluation (~2-4K tokens)
+│   ├── evaluate-cv-deepdive.md      # Workflow: Deep dive evaluation (~8-15K tokens)
 │   ├── generate-template.md         # Workflow: Generate CSS templates
 │   └── git-branch-pr.md             # Workflow: Branch & PR management
 ├── PROJECT_CONTEXT.md               # Comprehensive project documentation
@@ -122,10 +124,10 @@ Tracks:
 
 ---
 
-### workflows/evaluate-cv.md
-**Workflow: Evaluate and critique CV with scoring**
+### workflows/evaluate-cv-quick.md
+**Workflow: Quick CV evaluation (~2K-4K output tokens)**
 
-**Key Principle:** Provides scored analysis using a 6-category framework
+**Key Principle:** Fast, lightweight scored analysis for iteration cycles
 
 **Features:**
 - 6-category scoring (Content, Structure, Impact, ATS, Relevance, Presentation)
@@ -134,7 +136,24 @@ Tracks:
 - Optional interactive HTML dashboard (neo-brutalism theme)
 - References `references/cv-evaluation-framework.md` for rubric
 
-**Execute:** `/evaluate-cv`
+**Execute:** `/evaluate-cv-quick`
+
+---
+
+### workflows/evaluate-cv-deepdive.md
+**Workflow: Comprehensive CV evaluation (~8K-15K output tokens)**
+
+**Key Principle:** Evidence-based evaluation with 10 mandatory insight quality standards
+
+**Everything in Quick mode, plus:**
+- Positioning Diagnosis, Career Arc Analysis
+- Evidence-based citations (every claim cites specific CV content)
+- Actionable rewrite examples (every suggestion includes replacement text)
+- Score impact estimates, contradiction detection
+- Top 3 high-impact actions with combined score projection
+- ≥80% specificity guarantee
+
+**Execute:** `/evaluate-cv-deepdive`
 
 ---
 
@@ -148,7 +167,14 @@ Detailed guide covering ATS optimization, action verbs, career-type consideratio
 ### references/cv-evaluation-framework.md
 **Reference: CV scoring framework**
 
-Complete evaluation rubric with 6 weighted categories, composite scoring, job-targeted addon, and section-specific criteria. Loaded by `/evaluate-cv` when performing evaluations.
+Complete evaluation rubric with 6 weighted categories, composite scoring, job-targeted addon, and section-specific criteria. Loaded by `/evaluate-cv-quick` and `/evaluate-cv-deepdive` workflows.
+
+---
+
+### references/benchmark-testing-framework.md
+**Reference: Workflow benchmarking standard**
+
+Standardized procedure for comparing workflow performance. Provides methodology, metrics templates, Quality Index formula, execution protocol, and decision criteria for adopting workflow changes.
 
 ---
 
@@ -160,7 +186,8 @@ Complete evaluation rubric with 6 weighted categories, composite scoring, job-ta
 3. Execute workflows:
    - `/add-cv-section` - Update `index.md`
    - `/build-cv-wizard` - Build CV from data sources
-   - `/evaluate-cv` - Evaluate CV with scoring
+   - `/evaluate-cv-quick` - Quick CV evaluation
+   - `/evaluate-cv-deepdive` - Deep dive evaluation
    - `/generate-template` - Create CSS templates
 
 ### For Developers

--- a/.agent/references/benchmark-testing-framework.md
+++ b/.agent/references/benchmark-testing-framework.md
@@ -1,0 +1,256 @@
+# Benchmark Testing Framework
+
+**Purpose:** Standardized procedure for comparing workflow performance. Use this framework whenever you need to benchmark, evaluate improvements, or compare workflow variants.
+
+**When to use:**
+- Enhancing or refactoring an existing workflow
+- Comparing two workflow approaches
+- Validating that changes improve output quality
+- Regression testing after workflow modifications
+
+---
+
+## 1. Methodology
+
+### 1.1 Test Design Principles
+
+- **Controlled comparison:** Same inputs, different workflow instructions
+- **Empty context:** Each evaluation starts from empty agent context (no prior knowledge)
+- **Multiple samples:** Minimum 2 test samples to test generalizability
+  - 1 real-world sample (actual project data)
+  - 1 synthetic sample (designed to test different challenges)
+- **Blind measurement:** Criteria defined before running tests, not after seeing results
+
+### 1.2 Sample Selection
+
+| Sample | Source | Purpose |
+|--------|--------|---------|
+| Sample 1 | Real data from project | Tests real-world performance |
+| Sample 2 | Synthetic (AI-generated) | Tests edge cases, different challenges |
+| Sample N | Additional as needed | Tests specific scenarios |
+
+**Synthetic sample guidelines:**
+- Represent a different persona/scenario than the real sample
+- Include known weaknesses the workflow should catch
+- Include challenges the real sample doesn't cover
+- Document the design rationale
+
+### 1.3 Control vs Treatment
+
+| Group | Description |
+|-------|-------------|
+| **Control** (Current) | Run using the existing workflow exactly as documented |
+| **Treatment** (Enhanced) | Run using the proposed new/modified workflow |
+
+Both groups must process the same samples with the same scope parameters.
+
+---
+
+## 2. Measurement Criteria
+
+### 2.1 Standard Metrics Template
+
+Every benchmark must define metrics before execution. Use this template and adapt as needed:
+
+#### Binary Metrics (0/1)
+Presence/absence of specific output patterns.
+
+```
+| # | Metric Name | Description | Control | Treatment |
+|---|-------------|-------------|---------|-----------|
+| 1 | [Pattern]   | [What to look for] | 0/1 | 0/1 |
+```
+
+#### Count Metrics
+Number of specific items in the output.
+
+```
+| # | Metric Name | Description | Control | Treatment |
+|---|-------------|-------------|---------|-----------|
+| 1 | [Item]      | [What to count] | N | N |
+```
+
+#### Percentage Metrics
+Ratios calculated from output analysis.
+
+```
+| # | Metric Name | Description | Control | Treatment |
+|---|-------------|-------------|---------|-----------|
+| 1 | [Ratio]     | [How calculated] | X% | X% |
+```
+
+### 2.2 Example: CV Evaluation Metrics
+
+For reference, the CV evaluation benchmark used these 10 criteria:
+
+| # | Metric | Type | Description |
+|---|--------|------|-------------|
+| 1 | Positioning Diagnosis | 0/1 | One-line gap framing present? |
+| 2 | Evidence Citations | count | Exact CV quotes referenced |
+| 3 | Rewrite Examples | count | Concrete replacement text provided |
+| 4 | Score Impact Estimates | 0/1 | Numerical improvement estimates? |
+| 5 | Contradiction Detection | count | Inconsistencies identified |
+| 6 | Current Role Priority | 0/1 | Most recent role analyzed deepest? |
+| 7 | Career Arc Analysis | 0/1 | Career trajectory mapped? |
+| 8 | Top N Actions + Impact | 0/1 | Ranked actions with estimates? |
+| 9 | Total Actionable Items | count | Specific, implementable suggestions |
+| 10 | Specificity Score | % | Ratio of specific-to-generic suggestions |
+
+---
+
+## 3. Execution Protocol
+
+### Step 1: Prepare
+
+1. Create benchmark directory:
+   ```
+   docs/[feature]/benchmark/
+   ├── samples/           # Test samples
+   ├── current-workflow/   # Control group output
+   └── enhanced-workflow/  # Treatment group output
+   ```
+2. Define metrics (from Section 2)
+3. Create or select test samples (from Section 1.2)
+4. Document any modified framework/reference files in `enhanced-workflow/`
+
+### Step 2: Execute Control Group
+
+For each sample:
+1. Start from empty context (no prior analysis)
+2. Follow the current workflow exactly as documented
+3. Save output to `current-workflow/eval-sample-N.md`
+4. Optionally generate HTML report: `current-workflow/eval-sample-N.html`
+
+### Step 3: Execute Treatment Group
+
+For each sample:
+1. Start from empty context (no prior analysis)
+2. Follow the enhanced/modified workflow with all proposed changes
+3. Save output to `enhanced-workflow/eval-sample-N.md`
+4. Optionally generate HTML report: `enhanced-workflow/eval-sample-N.html`
+
+### Step 4: Measure
+
+1. Score each evaluation output against the defined metrics
+2. Calculate per-sample scores for both groups
+3. Calculate averages across samples
+4. Calculate deltas (Treatment - Control)
+
+### Step 5: Report
+
+Generate `benchmark-results.html` (or `.md`) with:
+- Methodology summary
+- Per-sample metrics table
+- Averaged metrics table
+- Quality Index scores
+- Side-by-side examples
+- Trade-off analysis
+- Verdict
+
+---
+
+## 4. Quality Index Formula
+
+The Quality Index provides a single weighted score for apples-to-apples comparison.
+
+### Calculation
+
+```
+Quality Index = (Binary Score × 0.40) + (Volume Score × 0.30) + (Specificity × 0.30)
+```
+
+Where:
+- **Binary Score** = (total binary metrics achieved / total binary metrics possible) × 10
+- **Volume Score** = normalize count metrics to 0-10 scale based on reasonable expectations
+- **Specificity** = specificity percentage normalized to 0-10 scale
+
+### Normalization for Volume Metrics
+
+Define "reasonable expectations" per metric before testing:
+
+| Metric | Floor (0) | Ceiling (10) |
+|--------|-----------|--------------|
+| Evidence Citations | 0 | 30+ |
+| Rewrite Examples | 0 | 15+ |
+| Actionable Items | 0 | 20+ |
+
+Formula: `Score = min(10, (actual / ceiling) × 10)`
+
+### Interpretation
+
+| Quality Index | Rating | Meaning |
+|---------------|--------|---------|
+| 9.0 - 10.0 | Exceptional | Comprehensive, evidence-based, highly actionable |
+| 7.0 - 8.9 | Strong | Good quality with minor gaps |
+| 5.0 - 6.9 | Adequate | Functional but missing key patterns |
+| 3.0 - 4.9 | Weak | Significant quality gaps |
+| 0.0 - 2.9 | Poor | Generic, lacks specificity |
+
+---
+
+## 5. Trade-Off Analysis
+
+Every benchmark report must include trade-off analysis:
+
+| Dimension | Control | Treatment | Verdict |
+|-----------|---------|-----------|---------|
+| Output length | X lines | Y lines | [Acceptable/Concerning] |
+| Token cost | ~Xk tokens | ~Yk tokens | [Acceptable/Concerning] |
+| Generation time | ~Xs | ~Ys | [Acceptable/Concerning] |
+| Cognitive load | [Low/Med/High] | [Low/Med/High] | [Acceptable/Concerning] |
+| Consistency guarantee | [Description] | [Description] | [Better/Worse/Same] |
+
+---
+
+## 6. Decision Framework
+
+### When to Adopt Changes
+
+| Condition | Action |
+|-----------|--------|
+| Quality Index improves ≥20% with acceptable trade-offs | ✅ Adopt |
+| Quality Index improves ≥20% but trade-offs are concerning | ⚠️ Adopt with modifications |
+| Quality Index improves <20% | 🔶 Consider if trade-offs justify |
+| Quality Index decreases | ❌ Reject |
+
+### When to Create Separate Variants
+
+If the treatment workflow has significantly different trade-offs (e.g., 3× token cost), consider creating two variants instead of replacing:
+- **Quick variant:** Lightweight, fast iteration
+- **Deep variant:** Comprehensive, resource-intensive
+
+This was the approach taken for `/evaluate-cv-quick` vs `/evaluate-cv-deepdive`.
+
+---
+
+## 7. Benchmark Report Template
+
+```markdown
+# Benchmark: [Current Feature] vs [Enhanced Feature]
+
+## Methodology
+- Samples: [N] ([real/synthetic breakdown])
+- Evaluations: [N] ([samples × workflows])
+- Metrics: [N] objective criteria
+- Context: Empty (fresh agent per evaluation)
+
+## Results Summary
+| Metric | Control (avg) | Treatment (avg) | Delta |
+|--------|--------------|-----------------|-------|
+| ...    | ...          | ...             | ...   |
+| **Quality Index** | **X.X** | **X.X** | **+XX%** |
+
+## Trade-Off Analysis
+[Per Section 5]
+
+## Side-by-Side Examples
+[Show 2-3 concrete before/after output comparisons]
+
+## Verdict
+[Adopt / Adopt with modifications / Reject]
+[Justification citing specific metrics]
+```
+
+---
+
+_This framework is a project context reference. It is loaded by AI agents when performing benchmark tests or workflow comparisons._

--- a/.agent/references/cv-evaluation-framework.md
+++ b/.agent/references/cv-evaluation-framework.md
@@ -1,6 +1,6 @@
 # CV Evaluation Framework
 
-**Purpose:** Structured analysis framework for evaluating CV quality. Loaded by the `/evaluate-cv` workflow when performing scored evaluations.
+**Purpose:** Structured analysis framework for evaluating CV quality. Loaded by the `/evaluate-cv-quick` and `/evaluate-cv-deepdive` workflows when performing scored evaluations.
 
 ---
 
@@ -185,4 +185,89 @@ When the user provides a target job description, perform additional analysis:
 
 ---
 
-_This framework is loaded by the `/evaluate-cv` workflow when performing structured evaluations._
+## Insight Quality Standards
+
+The `/evaluate-cv-deepdive` workflow enforces all 10 standards below. Each standard is **mandatory** — the evaluation output must satisfy every one before being presented.
+
+### Standard 1: Positioning Diagnosis
+Create a one-line framing that captures the gap between the CV's current narrative and desired positioning.
+
+**Rule:** Compare what the CV currently communicates vs. what the candidate wants it to communicate.
+
+**Example:**
+> "Your CV reads as a **strong 2023-era DevOps engineer**, but not as a **2026 infrastructure engineer leveraging AI**."
+
+### Standard 2: Evidence-Based Analysis
+Every claim in the evaluation must cite specific content from the CV.
+
+**Rule:** Reference exact phrases, section names, or word choices. Never make vague claims.
+
+- ❌ Bad: "The profile summary needs improvement."
+- ✅ Good: "The phrase 'I am a fast learner and team player' (Profile Summary) uses first-person pronouns and clichés that weaken the professional tone."
+
+### Standard 3: Actionable Rewrite Examples
+Every improvement suggestion must include concrete replacement text.
+
+**Rule:** Show "before → after" or provide suggested new content.
+
+- ❌ Bad: "→ Suggestion: Make the summary more professional."
+- ✅ Good: "→ Suggested rewrite: 'Backend engineer with 4 years of experience building scalable APIs and microservices in Java and Python.'"
+
+### Standard 4: Estimated Score Impact
+For each major recommendation, estimate how much it would improve the composite score.
+
+**Rule:** Provide specific numerical estimates (e.g., "+0.5 to +1.0") and a combined estimate for top actions.
+
+**Example:**
+> "Implementing all 3 actions could move the composite score from **4.85** to approximately **6.5-7.0** (⚠️ Adequate → ✅ Strong)."
+
+### Standard 5: Contradiction Detection
+Actively scan for inconsistencies in dates, claims, narrative flow, or stated vs. demonstrated skills.
+
+**Rule:** Check for: timeline gaps, skills claimed but not evidenced, tense inconsistencies, narrative contradictions, stated goal vs. CV content misalignment.
+
+**Example:**
+> "Contradiction: Profile claims 'transition into DevOps' but Skills lists only 1 DevOps tool (Jenkins)."
+
+### Standard 6: Current Role Priority
+The most recent role must receive the deepest analysis and most detailed recommendations.
+
+**Rule:** The current role should have more analysis text than any other role. If it's the weakest entry, flag this prominently.
+
+**Example:**
+> "🚨 **Critical:** Your current role (most important entry) has **zero quantified achievements** and only lists responsibilities."
+
+### Standard 7: Career Arc Analysis
+Identify and articulate the implicit career trajectory, then assess whether it's clearly communicated.
+
+**Rule:** Map the progression explicitly (e.g., "Junior → Mid → Senior → [desired]"). Assess whether the CV tells this story.
+
+### Standard 8: Top N High-Impact Actions
+Conclude every evaluation with the top 3 highest-impact actions, ranked by estimated score improvement.
+
+**Rule:** Each action must include: what to do, why it matters, and estimated score impact. Include a combined estimate.
+
+**Example:**
+> 1. **Add metrics to current role** (Est. +1.0-1.5)
+> 2. **Rewrite Profile Summary** (Est. +0.5-1.0)
+> 3. **Categorize Technical Skills** (Est. +0.5)
+>
+> **Combined:** 4.85 → 6.5-7.0
+
+### Standard 9: Total Actionable Items
+Ensure at least 10-15 actionable items across the evaluation.
+
+**Rule:** Each item must be specific enough that the candidate can implement it without further guidance. "Improve your summary" is NOT actionable. "Remove first-person pronouns from Profile Summary and replace with third-person or omit subject" IS actionable.
+
+### Standard 10: Specificity Score Self-Check
+Before finalizing, review all suggestions. The ratio of specific-to-generic suggestions must be ≥80%.
+
+**Rule:**
+- **Specific:** References exact CV content, provides rewrite text, cites section
+- **Generic:** Could apply to any CV (e.g., "use more action verbs")
+
+If a suggestion is generic, enhance it with a specific example from this CV.
+
+---
+
+_This framework is loaded by the `/evaluate-cv-quick` and `/evaluate-cv-deepdive` workflows when performing structured evaluations._

--- a/.agent/workflows/evaluate-cv-deepdive.md
+++ b/.agent/workflows/evaluate-cv-deepdive.md
@@ -1,0 +1,352 @@
+---
+description: Deep dive CV evaluation with 10 mandatory insight quality standards (~8K-15K output tokens)
+---
+
+# CV Evaluation — Deep Dive
+
+**Purpose:** Comprehensive, evidence-based critique of the CV in `index.md` with scored evaluation, 10 mandatory insight quality patterns, and optional HTML dashboard. Every claim is cited, every suggestion includes a rewrite example.
+
+> [!TIP]
+> **When to use Quick vs Deep Dive:**
+>
+> | Aspect | Quick (`/evaluate-cv-quick`) | Deep Dive (`/evaluate-cv-deepdive`) |
+> |--------|-----|-----------|
+> | Output tokens | ~2K-4K | ~8K-15K |
+> | Insight patterns | Best-effort | 10/10 mandatory |
+> | Evidence citations | Optional | Mandatory (every claim) |
+> | Rewrite examples | Optional | Mandatory (every suggestion) |
+> | Specificity | ~20-40% | ~80-95% |
+> | Best for | Quick checks, iteration cycles | Comprehensive review, major revisions |
+
+## Important Notes
+- **Evaluation target:** Evaluates content in `index.md` (single source of truth)
+- **Framework reference:** See `.agent/references/cv-evaluation-framework.md` for the complete scoring rubric and criteria
+- **Output formats:** Narrative analysis, score card, and optional HTML dashboard
+- **Content quality:** This workflow enforces 10 Insight Quality Standards — see Step 3.5
+
+---
+
+## Workflow Steps
+
+### Step 1: Scope Definition
+
+If the user has not already described their evaluation needs, ask questions one by one:
+
+**Question 1 — Scope:**
+```
+What would you like to evaluate?
+1. Entire CV
+2. Specific section(s) only
+```
+
+If option 2:
+```
+Which section(s)? (comma-separated)
+1. Profile Summary
+2. Technical Skills
+3. Professional Experience
+4. Education
+5. Activities (Articles/Certifications/Projects)
+6. Language
+```
+
+**Question 2 — Improvement Goals:**
+```
+What kind of improvement are you looking for?
+1. General review (overall quality check)
+2. Targeted for a specific job/role
+3. Career pivot / repositioning
+4. ATS optimization focus
+5. Specific concern (describe)
+```
+
+**Question 3 — Job Target (if applicable):**
+```
+Would you like to evaluate against a specific job posting?
+1. Yes (provide URL or paste description)
+2. No (general evaluation)
+```
+
+If yes, fetch and parse the job description using the same fallback chain:
+- Attempt `curl` → retry → Browser tool → ask user to paste the description
+
+---
+
+### Step 2: Read CV Content
+
+// turbo
+1. Read `index.md` completely
+2. If evaluating specific section(s), isolate the relevant content
+3. If job target provided, extract key requirements, skills, and keywords
+
+Present confirmation:
+```
+Evaluation scope:
+- Target: [Entire CV / Specific section(s)]
+- Goal: [General review / Job-targeted / etc.]
+- Job target: [Job title at Company / None]
+- Mode: Deep Dive (comprehensive evaluation with 10 insight standards)
+
+Proceeding with evaluation...
+```
+
+---
+
+### Step 3: Analyze with Framework
+
+Load and apply the evaluation framework from `.agent/references/cv-evaluation-framework.md`.
+
+**For each of the 6 categories, evaluate and score 1-10:**
+
+1. **Content Quality** (25%) — Grammar, completeness, professional tone
+2. **Structure & Formatting** (15%) — Logical flow, formatting consistency
+3. **Impact & Metrics** (20%) — Quantified achievements, action verbs
+4. **ATS Compatibility** (15%) — Keywords, standard headings, parseability
+5. **Relevance** (15%) — Alignment to career goals or target job
+6. **Professional Presentation** (10%) — First impression, readability, length
+
+Calculate composite score:
+```
+Composite = (CQ × 0.25) + (SF × 0.15) + (IM × 0.20) + 
+            (ATS × 0.15) + (REL × 0.15) + (PP × 0.10)
+```
+
+**If job target is provided**, also perform:
+- Keyword match analysis (% of job keywords found in CV)
+- Requirement gap matrix (must-have / preferred / nice-to-have)
+
+---
+
+### Step 3.5: Apply Insight Quality Standards
+
+**MANDATORY.** After completing the framework analysis, verify your evaluation output includes ALL 10 standards defined in `.agent/references/cv-evaluation-framework.md` § Insight Quality Standards. If any are missing, add them before proceeding to Step 4.
+
+**Checklist (all required):**
+- [ ] 1. Positioning Diagnosis — one-line gap framing (current vs. desired narrative)
+- [ ] 2. Evidence Citations — every claim quotes specific CV content
+- [ ] 3. Rewrite Examples — every suggestion includes replacement text
+- [ ] 4. Score Impact Estimates — numerical improvement per recommendation
+- [ ] 5. Contradiction Detection — inconsistencies between sections
+- [ ] 6. Current Role Priority — deepest analysis on most recent role
+- [ ] 7. Career Arc Analysis — map career trajectory explicitly
+- [ ] 8. Top 3 Actions + Impact — ranked by estimated score improvement
+- [ ] 9. ≥10 Actionable Items — specific enough to implement without guidance
+- [ ] 10. ≥80% Specificity — self-check ratio before presenting
+
+---
+
+### Step 4: Generate Results — Narrative
+
+Present a human-readable analysis incorporating all 10 insight standards:
+
+```
+# CV Evaluation Results — Deep Dive
+
+## Positioning Diagnosis
+[One-line framing of the gap — Standard 1]
+
+## Career Arc Analysis
+[Career trajectory mapping — Standard 7]
+
+## Overall Assessment
+[2-3 sentence overview citing specific CV content — Standard 2]
+
+## Strengths
+- ✅ [Strength 1 with EXACT evidence from CV — Standard 2]
+- ✅ [Strength 2 with citation]
+- ✅ [Strength 3 with citation]
+
+## Areas for Improvement
+
+### 🔴 High Priority
+- [Issue with EXACT quote from CV — Standard 2]
+  → Rewrite: [Complete replacement text — Standard 3]
+  → Impact: [Score estimate — Standard 4]
+
+### 🟡 Medium Priority
+- [Issue with citation]
+  → Rewrite: [Replacement text]
+  → Impact: [Score estimate]
+
+### 🟢 Low Priority
+- [Minor issue with citation]
+  → Rewrite: [Replacement text]
+
+## Contradictions Found
+[List of inconsistencies — Standard 5]
+
+## Section-by-Section Analysis
+
+### [Current Role — MOST DETAILED — Standard 6]
+[In-depth analysis with citations and rewrites]
+
+### [Previous Roles]
+[Analysis with citations and rewrites]
+
+### [Other Sections]
+[Analysis]
+
+## 🎯 Top 3 High-Impact Actions — Standard 8
+| # | Action | Est. Impact |
+|---|--------|-------------|
+| 1 | [Action with context] | +X.X |
+| 2 | [Action with context] | +X.X |
+| 3 | [Action with context] | +X.X |
+
+Combined: X.XX → X.XX ([Current Rating] → [Target Rating])
+```
+
+If job-targeted, add:
+```
+## Job Target Analysis: [Job Title] at [Company]
+
+### Keyword Match: [X]%
+[List of matched and missing keywords]
+
+### Requirement Gap Analysis
+| Requirement | Status | Evidence | Recommendation |
+|-------------|--------|----------|----------------|
+| [Req 1]     | ✅/⚠️/❌ | [Where] | [How to fix] |
+```
+
+**Self-check before presenting:** Count actionable items (Standard 9) and calculate specificity ratio (Standard 10). If below thresholds, enhance before presenting.
+
+---
+
+### Step 5: Generate Results — Score Card
+
+Present the scored summary with score impact row:
+
+```
+## Score Card
+
+| Category                | Score | Weight | Weighted | Justification |
+|-------------------------|-------|--------|----------|---------------|
+| Content Quality         | X/10  | 25%    | X.XX     | [1-line why]  |
+| Structure & Formatting  | X/10  | 15%    | X.XX     | [1-line why]  |
+| Impact & Metrics        | X/10  | 20%    | X.XX     | [1-line why]  |
+| ATS Compatibility       | X/10  | 15%    | X.XX     | [1-line why]  |
+| Relevance               | X/10  | 15%    | X.XX     | [1-line why]  |
+| Professional Presentation | X/10 | 10%   | X.XX     | [1-line why]  |
+|-------------------------|-------|--------|----------|---------------|
+| **Composite Score**     |       |        | **X.XX** |               |
+
+Rating: [⭐ Exceptional / ✅ Strong / ⚠️ Adequate / 🔶 Needs Work / 🔴 Major Revision]
+
+**If all top 3 actions implemented:** X.XX → ~X.XX ([Target Rating])
+```
+
+---
+
+### Step 6: Optional HTML Dashboard
+
+Ask user:
+```
+Would you like to generate an interactive web dashboard for these results?
+1. Yes
+2. No
+```
+
+If yes:
+
+**Check for existing dashboard:**
+// turbo
+```bash
+ls docs/evaluation/*.html 2>/dev/null
+```
+
+If files exist:
+```
+Found existing evaluation dashboard(s):
+- [filename(s)]
+
+Would you like to:
+1. Replace the existing dashboard
+2. Create a new file (with timestamp suffix)
+```
+
+**Generate the dashboard:**
+
+Create an HTML file at `docs/evaluation/cv-evaluation.html` (or timestamped variant) with:
+
+**Design: Neo-Brutalism Theme**
+- Bold black borders (3-4px)
+- Vibrant accent colors (bright yellow, electric blue, hot pink)
+- Strong typography (large headings, monospace accents)
+- Offset box shadows for depth
+- Minimal gradients — flat, bold color blocks
+- Interactive hover states with transform effects
+
+**Dashboard sections:**
+1. **Header** — "CV Evaluation Report — Deep Dive" with date and target info
+2. **Positioning Diagnosis** — Highlighted one-liner at top
+3. **Career Arc** — Visual career timeline
+4. **Composite Score** — Large, prominent score display with rating badge + projected score
+5. **Category Breakdown** — Visual score bars with justification tooltips
+6. **Strengths & Improvements** — Expandable cards with evidence citations and rewrite examples
+7. **Contradictions** — Highlighted contradiction cards
+8. **Section Analysis** — Tabbed or accordion view per CV section (current role first, deepest)
+9. **Top 3 Actions** — Action cards with impact estimates
+10. **Job Match** (if applicable) — Keyword match visualization, gap table
+11. **Personal Touch Section** (at bottom):
+    - A motivational quote (rotate from a curated list, or select contextually)
+    - Generated by: [AI Agent Model Name]
+    - "Brought to you by [doctor500](https://github.com/doctor500) • [doctor500/cv](https://github.com/doctor500/cv)"
+
+**Requirements:** Single self-contained HTML file (inline CSS + JS), responsive, print-friendly.
+
+After generation, offer preview in browser or continue.
+
+---
+
+### Step 7: Iteration
+
+After presenting results:
+```
+What would you like to do next?
+1. Re-evaluate after making changes to index.md
+2. Deep-dive into a specific section
+3. Get rewrite suggestions for specific bullets
+4. Evaluate against a (different) job posting
+5. Switch to /evaluate-cv-quick for faster iteration
+6. Done
+```
+
+If option 1: Return to Step 2 with updated content.
+If option 2-4: Perform additional targeted analysis.
+If option 5: Run the quick workflow.
+
+---
+
+## Example Output (abbreviated)
+
+> **Positioning Diagnosis:** Your CV reads as a **strong 2023-era DevOps engineer**, but not as a **2026 infrastructure engineer leveraging AI**.
+
+> **Career Arc:** Helpdesk → Sysadmin → DevOps → [desired: AI-Infra]. Progression visible but not articulated.
+
+> **🔴 High Priority:** Profile Summary says "passion for automation" but omits AI/ML despite Agentic AI goal.
+> → Rewrite: "Infrastructure engineer with 6+ years building cloud-native platforms, now applying AI agents to automate operational workflows."
+> → Impact: Est. +1.0 to +1.5
+
+> **Top 3 Actions:**
+> | # | Action | Est. Impact |
+> |---|--------|-------------|
+> | 1 | Reposition summary | +1.0-1.5 |
+> | 2 | Add AI project | +0.5-1.0 |
+> | 3 | Quantify current role | +0.5 |
+> Combined: 6.85 → 8.5-9.0 (✅ Strong → ⭐ Exceptional)
+
+---
+
+## Error Handling
+
+- **Job URL unreachable:** Fallback chain (curl → browser → paste)
+- **Section not found in index.md:** Notify user, list available sections
+- **Empty CV:** Suggest using `/build-cv-wizard` workflow first
+- **Dashboard generation fails:** Fall back to markdown-only output
+- **Previous dashboard exists:** Always ask before overwriting
+- **Insight standard missing:** Self-check before presenting (Step 4 self-check)
+
+---
+
+_This is the comprehensive evaluation workflow with 10 mandatory insight quality standards. For lightweight, fast iteration, use `/evaluate-cv-quick`._

--- a/.agent/workflows/evaluate-cv-quick.md
+++ b/.agent/workflows/evaluate-cv-quick.md
@@ -1,10 +1,22 @@
 ---
-description: Evaluate and critique CV with scoring framework and optional web dashboard
+description: Quick CV evaluation with scoring framework (lightweight, ~2K-4K output tokens)
 ---
 
-# CV Evaluation Workflow
+# CV Evaluation — Quick
 
-**Purpose:** Provide fair critique, actionable suggestions, and scored evaluation for the CV in `index.md`. Optionally generate an interactive HTML dashboard to visualize results.
+**Purpose:** Fast, structured critique of the CV in `index.md` with scored evaluation and optional HTML dashboard. Lightweight version optimized for iteration cycles.
+
+> [!TIP]
+> **When to use Quick vs Deep Dive:**
+>
+> | Aspect | Quick (`/evaluate-cv-quick`) | Deep Dive (`/evaluate-cv-deepdive`) |
+> |--------|-----|-----------|
+> | Output tokens | ~2K-4K | ~8K-15K |
+> | Insight patterns | Best-effort | 10/10 mandatory |
+> | Evidence citations | Optional | Mandatory (every claim) |
+> | Rewrite examples | Optional | Mandatory (every suggestion) |
+> | Specificity | ~20-40% | ~80-95% |
+> | Best for | Quick checks, iteration cycles | Comprehensive review, major revisions |
 
 ## Important Notes
 - **Evaluation target:** Evaluates content in `index.md` (single source of truth)
@@ -72,6 +84,7 @@ Evaluation scope:
 - Target: [Entire CV / Specific section(s)]
 - Goal: [General review / Job-targeted / etc.]
 - Job target: [Job title at Company / None]
+- Mode: Quick (lightweight evaluation)
 
 Proceeding with evaluation...
 ```
@@ -265,11 +278,13 @@ What would you like to do next?
 2. Deep-dive into a specific section
 3. Get rewrite suggestions for specific bullets
 4. Evaluate against a (different) job posting
-5. Done
+5. Switch to /evaluate-cv-deepdive for comprehensive analysis
+6. Done
 ```
 
 If option 1: Return to Step 2 with updated content.
 If option 2-4: Perform additional targeted analysis.
+If option 5: Run the deep dive workflow.
 
 ---
 
@@ -289,49 +304,28 @@ If option 2-4: Perform additional targeted analysis.
     4. ATS optimization
     5. Specific concern
 
-👤: 2
+👤: 1
 
-🤖: Please provide the job posting URL or paste the description:
-
-👤: https://company.com/jobs/senior-devops-engineer
-
-🤖: Evaluating your CV against: Senior DevOps Engineer at Company...
+🤖: Evaluating your CV (Quick mode)...
 
     # CV Evaluation Results
 
     ## Overall Assessment
     Your CV presents a strong technical profile with excellent
-    quantified achievements. The infrastructure cost reduction
-    metrics are particularly impactful. However, some recent
-    role descriptions could be strengthened with more specific
-    outcomes.
+    quantified achievements...
 
     ## Score Card
     | Category                 | Score | Weight | Weighted |
     |--------------------------|-------|--------|----------|
     | Content Quality          | 8/10  | 25%    | 2.00     |
-    | Structure & Formatting   | 7/10  | 15%    | 1.05     |
-    | Impact & Metrics         | 8/10  | 20%    | 1.60     |
-    | ATS Compatibility        | 7/10  | 15%    | 1.05     |
-    | Relevance                | 9/10  | 15%    | 1.35     |
-    | Professional Presentation| 8/10  | 10%    | 0.80     |
-    | **Composite Score**      |       |        | **8.05** |
+    | ...                      | ...   | ...    | ...      |
+    | **Composite Score**      |       |        | **7.85** |
 
     Rating: ✅ Strong
 
-    [... detailed analysis follows ...]
-
-🤖: Would you like to generate an interactive web dashboard?
-    1. Yes
-    2. No
-
-👤: 1
-
-🤖: ✅ Dashboard generated at docs/evaluation/cv-evaluation.html
-    
-    You can customize the theme by editing CSS variables in the file.
-    
-    What would you like to do next?
+🤖: What would you like to do next?
+    ...
+    5. Switch to /evaluate-cv-deepdive for comprehensive analysis
 ```
 
 ---
@@ -346,4 +340,4 @@ If option 2-4: Perform additional targeted analysis.
 
 ---
 
-_This workflow evaluates content in `index.md`._
+_This is the lightweight evaluation workflow. For comprehensive, evidence-based evaluation with mandatory insight patterns, use `/evaluate-cv-deepdive`._


### PR DESCRIPTION
## Summary

Split the single `evaluate-cv.md` workflow into two tiered variants and add a reusable benchmark testing framework.

### Changes

**Workflow Split:**
- **`evaluate-cv-quick.md`** (~2-4K output tokens) — Fast, lightweight evaluation for iteration cycles
- **`evaluate-cv-deepdive.md`** (~8-15K output tokens) — Comprehensive evaluation with 10 mandatory insight quality standards

**Framework Optimization:**
- Extracted 10 Insight Quality Standards from deepdive workflow to `cv-evaluation-framework.md` § Insight Quality Standards
- Deepdive workflow reduced from 16,700 → 11,946 chars (within Antigravity's 12K workflow content limit)

**New Reference:**
- `benchmark-testing-framework.md` — Standardized methodology for comparing workflow performance

**Documentation Updates:**
- `PROJECT_CONTEXT.md` — Directory tree, dual-variant evaluation section, benchmark entry
- `README.md` — Directory tree, workflow descriptions, quick start
- `QUICK_REFERENCE.md` — Updated command list

### File Summary

| Action | File |
|--------|------|
| ➕ New | `evaluate-cv-deepdive.md` |
| 📝 Renamed | `evaluate-cv.md` → `evaluate-cv-quick.md` (85% similar) |
| ➕ New | `benchmark-testing-framework.md` |
| ✏️ Modified | `cv-evaluation-framework.md` (+85 lines) |
| ✏️ Modified | `PROJECT_CONTEXT.md` |
| ✏️ Modified | `README.md` |
| ✏️ Modified | `QUICK_REFERENCE.md` |

### Related
- Follows from workflow/reference improvements in PR #42
- PR #43 (CV content fixes) should rebase after this merges