### PR TITLE
fix: comment page break divider

### DIFF
--- a/index.md
+++ b/index.md
@@ -160,7 +160,7 @@ Completed Business Intelligence minor, graduated in the 7th semester. Final GPA:
 [DevOps Engineering on AWS](https://1drv.ms/b/s!AgiuQdtA6DaqkRFlSnO8rKrDO8iQ?e=htxgE9), **from AWS**
 
 
-<div style="page-break-after: always;"></div>
+<!-- <div style="page-break-after: always;"></div> -->
 
 
 ### Latest Professional Projects


### PR DESCRIPTION
## Changes

- Commented out the page break `<div>` on line 163 of `index.md` between Training & Certifications and Latest Professional Projects sections.

## Verification

- [x] Change is minimal and straightforward