### PR TITLE
sync: page-release → main (README + CV content updates)

### DIFF
--- a/.agent/PROJECT_CONTEXT.md
+++ b/.agent/PROJECT_CONTEXT.md
@@ -25,12 +25,14 @@ A **markdown-based CV generator** using Jekyll static site generator, deployed v
 cv/
 ├── .agent/
 │   ├── references/
+│   │   ├── benchmark-testing-framework.md # Standardized workflow benchmarking
 │   │   ├── cv-construction-guide.md   # CV writing best practices & ATS tips
 │   │   └── cv-evaluation-framework.md # 6-category scoring framework
 │   ├── workflows/
 │   │   ├── add-cv-section.md          # Add content to index.md
 │   │   ├── build-cv-wizard.md         # Build CV from data sources
-│   │   ├── evaluate-cv.md             # Evaluate CV with scoring
+│   │   ├── evaluate-cv-quick.md       # Quick CV evaluation (~2-4K tokens)
+│   │   ├── evaluate-cv-deepdive.md    # Deep dive evaluation (~8-15K tokens)
 │   │   ├── generate-template.md       # Create CSS templates
 │   │   └── git-branch-pr.md           # Branch & PR workflow
 │   ├── PROJECT_CONTEXT.md
@@ -394,19 +396,49 @@ The profile contains valuable information that can be extracted:
 
 ---
 
-### 5. CV Evaluation
-**Command:** `/evaluate-cv`  
-**Purpose:** Evaluate and critique CV with scored analysis and optional web dashboard
+### 5. CV Evaluation (Two Variants)
+
+#### Quick Mode
+**Command:** `/evaluate-cv-quick`  
+**Token cost:** ~2K-4K output tokens  
+**Purpose:** Fast, lightweight CV evaluation for iteration cycles
 
 **Features:**
 - 6-category scoring framework (Content, Structure, Impact, ATS, Relevance, Presentation)
 - Dual output: narrative analysis + score card
 - Optional job-targeted evaluation with keyword matching
 - Optional interactive HTML dashboard (neo-brutalism theme)
-- Section-specific or full CV evaluation
 - References `.agent/references/cv-evaluation-framework.md` for scoring rubric
 
+#### Deep Dive Mode
+**Command:** `/evaluate-cv-deepdive`  
+**Token cost:** ~8K-15K output tokens  
+**Purpose:** Comprehensive, evidence-based evaluation with 10 mandatory insight quality standards
+
+**Everything in Quick mode, plus:**
+- Positioning Diagnosis (one-line gap framing)
+- Career Arc Analysis (trajectory mapping)
+- Evidence-based citations (every claim references specific CV content)
+- Actionable rewrite examples (every suggestion includes replacement text)
+- Score impact estimates (numerical improvement predictions)
+- Contradiction detection (inconsistencies between sections)
+- Top 3 high-impact actions with combined score projection
+- ≥80% specificity guarantee (self-checked before output)
+
 **Dashboard Output:** `docs/evaluation/` directory
+
+---
+
+### 6. Benchmark Testing Framework
+**Reference:** `.agent/references/benchmark-testing-framework.md`  
+**Purpose:** Standardized procedure for comparing workflow performance
+
+**When to use:**
+- Enhancing or refactoring an existing workflow
+- Comparing two workflow approaches
+- Validating that changes improve output quality
+
+**Provides:** Methodology, metrics templates, Quality Index formula, execution protocol, trade-off analysis framework, and decision criteria for adopting changes.
 
 ---
 

--- a/.agent/QUICK_REFERENCE.md
+++ b/.agent/QUICK_REFERENCE.md
@@ -116,7 +116,8 @@ git push origin feat/my-feature
 
 - `/add-cv-section` - Add content to index.md
 - `/build-cv-wizard` - Build CV from data sources
-- `/evaluate-cv` - Evaluate CV with scoring & dashboard
+- `/evaluate-cv-quick` - Quick CV evaluation (~2-4K tokens)
+- `/evaluate-cv-deepdive` - Deep dive evaluation (~8-15K tokens)
 - `/generate-template` - Create new CSS template
 - `/git-branch-pr` - Branch & PR workflow
 

--- a/.agent/README.md
+++ b/.agent/README.md
@@ -8,11 +8,13 @@ This directory contains AI agent configurations, workflows, and project context 
 .agent/
 ├── references/
 │   ├── cv-construction-guide.md     # CV writing best practices & ATS tips
-│   └── cv-evaluation-framework.md   # 6-category scoring framework
+│   ├── cv-evaluation-framework.md   # 6-category scoring framework
+│   └── benchmark-testing-framework.md # Workflow benchmarking standard
 ├── workflows/
 │   ├── add-cv-section.md            # Workflow: Update index.md with new sections
 │   ├── build-cv-wizard.md           # Workflow: Build CV from data sources
-│   ├── evaluate-cv.md               # Workflow: Evaluate CV with scoring
+│   ├── evaluate-cv-quick.md         # Workflow: Quick CV evaluation (~2-4K tokens)
+│   ├── evaluate-cv-deepdive.md      # Workflow: Deep dive evaluation (~8-15K tokens)
 │   ├── generate-template.md         # Workflow: Generate CSS templates
 │   └── git-branch-pr.md             # Workflow: Branch & PR management
 ├── PROJECT_CONTEXT.md               # Comprehensive project documentation
@@ -122,10 +124,10 @@ Tracks:
 
 ---
 
-### workflows/evaluate-cv.md
-**Workflow: Evaluate and critique CV with scoring**
+### workflows/evaluate-cv-quick.md
+**Workflow: Quick CV evaluation (~2K-4K output tokens)**
 
-**Key Principle:** Provides scored analysis using a 6-category framework
+**Key Principle:** Fast, lightweight scored analysis for iteration cycles
 
 **Features:**
 - 6-category scoring (Content, Structure, Impact, ATS, Relevance, Presentation)
@@ -134,7 +136,24 @@ Tracks:
 - Optional interactive HTML dashboard (neo-brutalism theme)
 - References `references/cv-evaluation-framework.md` for rubric
 
-**Execute:** `/evaluate-cv`
+**Execute:** `/evaluate-cv-quick`
+
+---
+
+### workflows/evaluate-cv-deepdive.md
+**Workflow: Comprehensive CV evaluation (~8K-15K output tokens)**
+
+**Key Principle:** Evidence-based evaluation with 10 mandatory insight quality standards
+
+**Everything in Quick mode, plus:**
+- Positioning Diagnosis, Career Arc Analysis
+- Evidence-based citations (every claim cites specific CV content)
+- Actionable rewrite examples (every suggestion includes replacement text)
+- Score impact estimates, contradiction detection
+- Top 3 high-impact actions with combined score projection
+- ≥80% specificity guarantee
+
+**Execute:** `/evaluate-cv-deepdive`
 
 ---
 
@@ -148,7 +167,14 @@ Detailed guide covering ATS optimization, action verbs, career-type consideratio
 ### references/cv-evaluation-framework.md
 **Reference: CV scoring framework**
 
-Complete evaluation rubric with 6 weighted categories, composite scoring, job-targeted addon, and section-specific criteria. Loaded by `/evaluate-cv` when performing evaluations.
+Complete evaluation rubric with 6 weighted categories, composite scoring, job-targeted addon, and section-specific criteria. Loaded by `/evaluate-cv-quick` and `/evaluate-cv-deepdive` workflows.
+
+---
+
+### references/benchmark-testing-framework.md
+**Reference: Workflow benchmarking standard**
+
+Standardized procedure for comparing workflow performance. Provides methodology, metrics templates, Quality Index formula, execution protocol, and decision criteria for adopting workflow changes.
 
 ---
 
@@ -160,7 +186,8 @@ Complete evaluation rubric with 6 weighted categories, composite scoring, job-ta
 3. Execute workflows:
    - `/add-cv-section` - Update `index.md`
    - `/build-cv-wizard` - Build CV from data sources
-   - `/evaluate-cv` - Evaluate CV with scoring
+   - `/evaluate-cv-quick` - Quick CV evaluation
+   - `/evaluate-cv-deepdive` - Deep dive evaluation
    - `/generate-template` - Create CSS templates
 
 ### For Developers

--- a/.agent/references/benchmark-testing-framework.md
+++ b/.agent/references/benchmark-testing-framework.md
@@ -1,0 +1,256 @@
+# Benchmark Testing Framework
+
+**Purpose:** Standardized procedure for comparing workflow performance. Use this framework whenever you need to benchmark, evaluate improvements, or compare workflow variants.
+
+**When to use:**
+- Enhancing or refactoring an existing workflow
+- Comparing two workflow approaches
+- Validating that changes improve output quality
+- Regression testing after workflow modifications
+
+---
+
+## 1. Methodology
+
+### 1.1 Test Design Principles
+
+- **Controlled comparison:** Same inputs, different workflow instructions
+- **Empty context:** Each evaluation starts from empty agent context (no prior knowledge)
+- **Multiple samples:** Minimum 2 test samples to test generalizability
+  - 1 real-world sample (actual project data)
+  - 1 synthetic sample (designed to test different challenges)
+- **Blind measurement:** Criteria defined before running tests, not after seeing results
+
+### 1.2 Sample Selection
+
+| Sample | Source | Purpose |
+|--------|--------|---------|
+| Sample 1 | Real data from project | Tests real-world performance |
+| Sample 2 | Synthetic (AI-generated) | Tests edge cases, different challenges |
+| Sample N | Additional as needed | Tests specific scenarios |
+
+**Synthetic sample guidelines:**
+- Represent a different persona/scenario than the real sample
+- Include known weaknesses the workflow should catch
+- Include challenges the real sample doesn't cover
+- Document the design rationale
+
+### 1.3 Control vs Treatment
+
+| Group | Description |
+|-------|-------------|
+| **Control** (Current) | Run using the existing workflow exactly as documented |
+| **Treatment** (Enhanced) | Run using the proposed new/modified workflow |
+
+Both groups must process the same samples with the same scope parameters.
+
+---
+
+## 2. Measurement Criteria
+
+### 2.1 Standard Metrics Template
+
+Every benchmark must define metrics before execution. Use this template and adapt as needed:
+
+#### Binary Metrics (0/1)
+Presence/absence of specific output patterns.
+
+```
+| # | Metric Name | Description | Control | Treatment |
+|---|-------------|-------------|---------|-----------|
+| 1 | [Pattern]   | [What to look for] | 0/1 | 0/1 |
+```
+
+#### Count Metrics
+Number of specific items in the output.
+
+```
+| # | Metric Name | Description | Control | Treatment |
+|---|-------------|-------------|---------|-----------|
+| 1 | [Item]      | [What to count] | N | N |
+```
+
+#### Percentage Metrics
+Ratios calculated from output analysis.
+
+```
+| # | Metric Name | Description | Control | Treatment |
+|---|-------------|-------------|---------|-----------|
+| 1 | [Ratio]     | [How calculated] | X% | X% |
+```
+
+### 2.2 Example: CV Evaluation Metrics
+
+For reference, the CV evaluation benchmark used these 10 criteria:
+
+| # | Metric | Type | Description |
+|---|--------|------|-------------|
+| 1 | Positioning Diagnosis | 0/1 | One-line gap framing present? |
+| 2 | Evidence Citations | count | Exact CV quotes referenced |
+| 3 | Rewrite Examples | count | Concrete replacement text provided |
+| 4 | Score Impact Estimates | 0/1 | Numerical improvement estimates? |
+| 5 | Contradiction Detection | count | Inconsistencies identified |
+| 6 | Current Role Priority | 0/1 | Most recent role analyzed deepest? |
+| 7 | Career Arc Analysis | 0/1 | Career trajectory mapped? |
+| 8 | Top N Actions + Impact | 0/1 | Ranked actions with estimates? |
+| 9 | Total Actionable Items | count | Specific, implementable suggestions |
+| 10 | Specificity Score | % | Ratio of specific-to-generic suggestions |
+
+---
+
+## 3. Execution Protocol
+
+### Step 1: Prepare
+
+1. Create benchmark directory:
+   ```
+   docs/[feature]/benchmark/
+   ├── samples/           # Test samples
+   ├── current-workflow/   # Control group output
+   └── enhanced-workflow/  # Treatment group output
+   ```
+2. Define metrics (from Section 2)
+3. Create or select test samples (from Section 1.2)
+4. Document any modified framework/reference files in `enhanced-workflow/`
+
+### Step 2: Execute Control Group
+
+For each sample:
+1. Start from empty context (no prior analysis)
+2. Follow the current workflow exactly as documented
+3. Save output to `current-workflow/eval-sample-N.md`
+4. Optionally generate HTML report: `current-workflow/eval-sample-N.html`
+
+### Step 3: Execute Treatment Group
+
+For each sample:
+1. Start from empty context (no prior analysis)
+2. Follow the enhanced/modified workflow with all proposed changes
+3. Save output to `enhanced-workflow/eval-sample-N.md`
+4. Optionally generate HTML report: `enhanced-workflow/eval-sample-N.html`
+
+### Step 4: Measure
+
+1. Score each evaluation output against the defined metrics
+2. Calculate per-sample scores for both groups
+3. Calculate averages across samples
+4. Calculate deltas (Treatment - Control)
+
+### Step 5: Report
+
+Generate `benchmark-results.html` (or `.md`) with:
+- Methodology summary
+- Per-sample metrics table
+- Averaged metrics table
+- Quality Index scores
+- Side-by-side examples
+- Trade-off analysis
+- Verdict
+
+---
+
+## 4. Quality Index Formula
+
+The Quality Index provides a single weighted score for apples-to-apples comparison.
+
+### Calculation
+
+```
+Quality Index = (Binary Score × 0.40) + (Volume Score × 0.30) + (Specificity × 0.30)
+```
+
+Where:
+- **Binary Score** = (total binary metrics achieved / total binary metrics possible) × 10
+- **Volume Score** = normalize count metrics to 0-10 scale based on reasonable expectations
+- **Specificity** = specificity percentage normalized to 0-10 scale
+
+### Normalization for Volume Metrics
+
+Define "reasonable expectations" per metric before testing:
+
+| Metric | Floor (0) | Ceiling (10) |
+|--------|-----------|--------------|
+| Evidence Citations | 0 | 30+ |
+| Rewrite Examples | 0 | 15+ |
+| Actionable Items | 0 | 20+ |
+
+Formula: `Score = min(10, (actual / ceiling) × 10)`
+
+### Interpretation
+
+| Quality Index | Rating | Meaning |
+|---------------|--------|---------|
+| 9.0 - 10.0 | Exceptional | Comprehensive, evidence-based, highly actionable |
+| 7.0 - 8.9 | Strong | Good quality with minor gaps |
+| 5.0 - 6.9 | Adequate | Functional but missing key patterns |
+| 3.0 - 4.9 | Weak | Significant quality gaps |
+| 0.0 - 2.9 | Poor | Generic, lacks specificity |
+
+---
+
+## 5. Trade-Off Analysis
+
+Every benchmark report must include trade-off analysis:
+
+| Dimension | Control | Treatment | Verdict |
+|-----------|---------|-----------|---------|
+| Output length | X lines | Y lines | [Acceptable/Concerning] |
+| Token cost | ~Xk tokens | ~Yk tokens | [Acceptable/Concerning] |
+| Generation time | ~Xs | ~Ys | [Acceptable/Concerning] |
+| Cognitive load | [Low/Med/High] | [Low/Med/High] | [Acceptable/Concerning] |
+| Consistency guarantee | [Description] | [Description] | [Better/Worse/Same] |
+
+---
+
+## 6. Decision Framework
+
+### When to Adopt Changes
+
+| Condition | Action |
+|-----------|--------|
+| Quality Index improves ≥20% with acceptable trade-offs | ✅ Adopt |
+| Quality Index improves ≥20% but trade-offs are concerning | ⚠️ Adopt with modifications |
+| Quality Index improves <20% | 🔶 Consider if trade-offs justify |
+| Quality Index decreases | ❌ Reject |
+
+### When to Create Separate Variants
+
+If the treatment workflow has significantly different trade-offs (e.g., 3× token cost), consider creating two variants instead of replacing:
+- **Quick variant:** Lightweight, fast iteration
+- **Deep variant:** Comprehensive, resource-intensive
+
+This was the approach taken for `/evaluate-cv-quick` vs `/evaluate-cv-deepdive`.
+
+---
+
+## 7. Benchmark Report Template
+
+```markdown
+# Benchmark: [Current Feature] vs [Enhanced Feature]
+
+## Methodology
+- Samples: [N] ([real/synthetic breakdown])
+- Evaluations: [N] ([samples × workflows])
+- Metrics: [N] objective criteria
+- Context: Empty (fresh agent per evaluation)
+
+## Results Summary
+| Metric | Control (avg) | Treatment (avg) | Delta |
+|--------|--------------|-----------------|-------|
+| ...    | ...          | ...             | ...   |
+| **Quality Index** | **X.X** | **X.X** | **+XX%** |
+
+## Trade-Off Analysis
+[Per Section 5]
+
+## Side-by-Side Examples
+[Show 2-3 concrete before/after output comparisons]
+
+## Verdict
+[Adopt / Adopt with modifications / Reject]
+[Justification citing specific metrics]
+```
+
+---
+
+_This framework is a project context reference. It is loaded by AI agents when performing benchmark tests or workflow comparisons._

--- a/.agent/references/cv-evaluation-framework.md
+++ b/.agent/references/cv-evaluation-framework.md
@@ -1,6 +1,6 @@
 # CV Evaluation Framework
 
-**Purpose:** Structured analysis framework for evaluating CV quality. Loaded by the `/evaluate-cv` workflow when performing scored evaluations.
+**Purpose:** Structured analysis framework for evaluating CV quality. Loaded by the `/evaluate-cv-quick` and `/evaluate-cv-deepdive` workflows when performing scored evaluations.
 
 ---
 
@@ -185,4 +185,89 @@ When the user provides a target job description, perform additional analysis:
 
 ---
 
-_This framework is loaded by the `/evaluate-cv` workflow when performing structured evaluations._
+## Insight Quality Standards
+
+The `/evaluate-cv-deepdive` workflow enforces all 10 standards below. Each standard is **mandatory** — the evaluation output must satisfy every one before being presented.
+
+### Standard 1: Positioning Diagnosis
+Create a one-line framing that captures the gap between the CV's current narrative and desired positioning.
+
+**Rule:** Compare what the CV currently communicates vs. what the candidate wants it to communicate.
+
+**Example:**
+> "Your CV reads as a **strong 2023-era DevOps engineer**, but not as a **2026 infrastructure engineer leveraging AI**."
+
+### Standard 2: Evidence-Based Analysis
+Every claim in the evaluation must cite specific content from the CV.
+
+**Rule:** Reference exact phrases, section names, or word choices. Never make vague claims.
+
+- ❌ Bad: "The profile summary needs improvement."
+- ✅ Good: "The phrase 'I am a fast learner and team player' (Profile Summary) uses first-person pronouns and clichés that weaken the professional tone."
+
+### Standard 3: Actionable Rewrite Examples
+Every improvement suggestion must include concrete replacement text.
+
+**Rule:** Show "before → after" or provide suggested new content.
+
+- ❌ Bad: "→ Suggestion: Make the summary more professional."
+- ✅ Good: "→ Suggested rewrite: 'Backend engineer with 4 years of experience building scalable APIs and microservices in Java and Python.'"
+
+### Standard 4: Estimated Score Impact
+For each major recommendation, estimate how much it would improve the composite score.
+
+**Rule:** Provide specific numerical estimates (e.g., "+0.5 to +1.0") and a combined estimate for top actions.
+
+**Example:**
+> "Implementing all 3 actions could move the composite score from **4.85** to approximately **6.5-7.0** (⚠️ Adequate → ✅ Strong)."
+
+### Standard 5: Contradiction Detection
+Actively scan for inconsistencies in dates, claims, narrative flow, or stated vs. demonstrated skills.
+
+**Rule:** Check for: timeline gaps, skills claimed but not evidenced, tense inconsistencies, narrative contradictions, stated goal vs. CV content misalignment.
+
+**Example:**
+> "Contradiction: Profile claims 'transition into DevOps' but Skills lists only 1 DevOps tool (Jenkins)."
+
+### Standard 6: Current Role Priority
+The most recent role must receive the deepest analysis and most detailed recommendations.
+
+**Rule:** The current role should have more analysis text than any other role. If it's the weakest entry, flag this prominently.
+
+**Example:**
+> "🚨 **Critical:** Your current role (most important entry) has **zero quantified achievements** and only lists responsibilities."
+
+### Standard 7: Career Arc Analysis
+Identify and articulate the implicit career trajectory, then assess whether it's clearly communicated.
+
+**Rule:** Map the progression explicitly (e.g., "Junior → Mid → Senior → [desired]"). Assess whether the CV tells this story.
+
+### Standard 8: Top N High-Impact Actions
+Conclude every evaluation with the top 3 highest-impact actions, ranked by estimated score improvement.
+
+**Rule:** Each action must include: what to do, why it matters, and estimated score impact. Include a combined estimate.
+
+**Example:**
+> 1. **Add metrics to current role** (Est. +1.0-1.5)
+> 2. **Rewrite Profile Summary** (Est. +0.5-1.0)
+> 3. **Categorize Technical Skills** (Est. +0.5)
+>
+> **Combined:** 4.85 → 6.5-7.0
+
+### Standard 9: Total Actionable Items
+Ensure at least 10-15 actionable items across the evaluation.
+
+**Rule:** Each item must be specific enough that the candidate can implement it without further guidance. "Improve your summary" is NOT actionable. "Remove first-person pronouns from Profile Summary and replace with third-person or omit subject" IS actionable.
+
+### Standard 10: Specificity Score Self-Check
+Before finalizing, review all suggestions. The ratio of specific-to-generic suggestions must be ≥80%.
+
+**Rule:**
+- **Specific:** References exact CV content, provides rewrite text, cites section
+- **Generic:** Could apply to any CV (e.g., "use more action verbs")
+
+If a suggestion is generic, enhance it with a specific example from this CV.
+
+---
+
+_This framework is loaded by the `/evaluate-cv-quick` and `/evaluate-cv-deepdive` workflows when performing structured evaluations._

--- a/.agent/workflows/evaluate-cv-deepdive.md
+++ b/.agent/workflows/evaluate-cv-deepdive.md
@@ -1,0 +1,352 @@
+---
+description: Deep dive CV evaluation with 10 mandatory insight quality standards (~8K-15K output tokens)
+---
+
+# CV Evaluation — Deep Dive
+
+**Purpose:** Comprehensive, evidence-based critique of the CV in `index.md` with scored evaluation, 10 mandatory insight quality patterns, and optional HTML dashboard. Every claim is cited, every suggestion includes a rewrite example.
+
+> [!TIP]
+> **When to use Quick vs Deep Dive:**
+>
+> | Aspect | Quick (`/evaluate-cv-quick`) | Deep Dive (`/evaluate-cv-deepdive`) |
+> |--------|-----|-----------|
+> | Output tokens | ~2K-4K | ~8K-15K |
+> | Insight patterns | Best-effort | 10/10 mandatory |
+> | Evidence citations | Optional | Mandatory (every claim) |
+> | Rewrite examples | Optional | Mandatory (every suggestion) |
+> | Specificity | ~20-40% | ~80-95% |
+> | Best for | Quick checks, iteration cycles | Comprehensive review, major revisions |
+
+## Important Notes
+- **Evaluation target:** Evaluates content in `index.md` (single source of truth)
+- **Framework reference:** See `.agent/references/cv-evaluation-framework.md` for the complete scoring rubric and criteria
+- **Output formats:** Narrative analysis, score card, and optional HTML dashboard
+- **Content quality:** This workflow enforces 10 Insight Quality Standards — see Step 3.5
+
+---
+
+## Workflow Steps
+
+### Step 1: Scope Definition
+
+If the user has not already described their evaluation needs, ask questions one by one:
+
+**Question 1 — Scope:**
+```
+What would you like to evaluate?
+1. Entire CV
+2. Specific section(s) only
+```
+
+If option 2:
+```
+Which section(s)? (comma-separated)
+1. Profile Summary
+2. Technical Skills
+3. Professional Experience
+4. Education
+5. Activities (Articles/Certifications/Projects)
+6. Language
+```
+
+**Question 2 — Improvement Goals:**
+```
+What kind of improvement are you looking for?
+1. General review (overall quality check)
+2. Targeted for a specific job/role
+3. Career pivot / repositioning
+4. ATS optimization focus
+5. Specific concern (describe)
+```
+
+**Question 3 — Job Target (if applicable):**
+```
+Would you like to evaluate against a specific job posting?
+1. Yes (provide URL or paste description)
+2. No (general evaluation)
+```
+
+If yes, fetch and parse the job description using the same fallback chain:
+- Attempt `curl` → retry → Browser tool → ask user to paste the description
+
+---
+
+### Step 2: Read CV Content
+
+// turbo
+1. Read `index.md` completely
+2. If evaluating specific section(s), isolate the relevant content
+3. If job target provided, extract key requirements, skills, and keywords
+
+Present confirmation:
+```
+Evaluation scope:
+- Target: [Entire CV / Specific section(s)]
+- Goal: [General review / Job-targeted / etc.]
+- Job target: [Job title at Company / None]
+- Mode: Deep Dive (comprehensive evaluation with 10 insight standards)
+
+Proceeding with evaluation...
+```
+
+---
+
+### Step 3: Analyze with Framework
+
+Load and apply the evaluation framework from `.agent/references/cv-evaluation-framework.md`.
+
+**For each of the 6 categories, evaluate and score 1-10:**
+
+1. **Content Quality** (25%) — Grammar, completeness, professional tone
+2. **Structure & Formatting** (15%) — Logical flow, formatting consistency
+3. **Impact & Metrics** (20%) — Quantified achievements, action verbs
+4. **ATS Compatibility** (15%) — Keywords, standard headings, parseability
+5. **Relevance** (15%) — Alignment to career goals or target job
+6. **Professional Presentation** (10%) — First impression, readability, length
+
+Calculate composite score:
+```
+Composite = (CQ × 0.25) + (SF × 0.15) + (IM × 0.20) + 
+            (ATS × 0.15) + (REL × 0.15) + (PP × 0.10)
+```
+
+**If job target is provided**, also perform:
+- Keyword match analysis (% of job keywords found in CV)
+- Requirement gap matrix (must-have / preferred / nice-to-have)
+
+---
+
+### Step 3.5: Apply Insight Quality Standards
+
+**MANDATORY.** After completing the framework analysis, verify your evaluation output includes ALL 10 standards defined in `.agent/references/cv-evaluation-framework.md` § Insight Quality Standards. If any are missing, add them before proceeding to Step 4.
+
+**Checklist (all required):**
+- [ ] 1. Positioning Diagnosis — one-line gap framing (current vs. desired narrative)
+- [ ] 2. Evidence Citations — every claim quotes specific CV content
+- [ ] 3. Rewrite Examples — every suggestion includes replacement text
+- [ ] 4. Score Impact Estimates — numerical improvement per recommendation
+- [ ] 5. Contradiction Detection — inconsistencies between sections
+- [ ] 6. Current Role Priority — deepest analysis on most recent role
+- [ ] 7. Career Arc Analysis — map career trajectory explicitly
+- [ ] 8. Top 3 Actions + Impact — ranked by estimated score improvement
+- [ ] 9. ≥10 Actionable Items — specific enough to implement without guidance
+- [ ] 10. ≥80% Specificity — self-check ratio before presenting
+
+---
+
+### Step 4: Generate Results — Narrative
+
+Present a human-readable analysis incorporating all 10 insight standards:
+
+```
+# CV Evaluation Results — Deep Dive
+
+## Positioning Diagnosis
+[One-line framing of the gap — Standard 1]
+
+## Career Arc Analysis
+[Career trajectory mapping — Standard 7]
+
+## Overall Assessment
+[2-3 sentence overview citing specific CV content — Standard 2]
+
+## Strengths
+- ✅ [Strength 1 with EXACT evidence from CV — Standard 2]
+- ✅ [Strength 2 with citation]
+- ✅ [Strength 3 with citation]
+
+## Areas for Improvement
+
+### 🔴 High Priority
+- [Issue with EXACT quote from CV — Standard 2]
+  → Rewrite: [Complete replacement text — Standard 3]
+  → Impact: [Score estimate — Standard 4]
+
+### 🟡 Medium Priority
+- [Issue with citation]
+  → Rewrite: [Replacement text]
+  → Impact: [Score estimate]
+
+### 🟢 Low Priority
+- [Minor issue with citation]
+  → Rewrite: [Replacement text]
+
+## Contradictions Found
+[List of inconsistencies — Standard 5]
+
+## Section-by-Section Analysis
+
+### [Current Role — MOST DETAILED — Standard 6]
+[In-depth analysis with citations and rewrites]
+
+### [Previous Roles]
+[Analysis with citations and rewrites]
+
+### [Other Sections]
+[Analysis]
+
+## 🎯 Top 3 High-Impact Actions — Standard 8
+| # | Action | Est. Impact |
+|---|--------|-------------|
+| 1 | [Action with context] | +X.X |
+| 2 | [Action with context] | +X.X |
+| 3 | [Action with context] | +X.X |
+
+Combined: X.XX → X.XX ([Current Rating] → [Target Rating])
+```
+
+If job-targeted, add:
+```
+## Job Target Analysis: [Job Title] at [Company]
+
+### Keyword Match: [X]%
+[List of matched and missing keywords]
+
+### Requirement Gap Analysis
+| Requirement | Status | Evidence | Recommendation |
+|-------------|--------|----------|----------------|
+| [Req 1]     | ✅/⚠️/❌ | [Where] | [How to fix] |
+```
+
+**Self-check before presenting:** Count actionable items (Standard 9) and calculate specificity ratio (Standard 10). If below thresholds, enhance before presenting.
+
+---
+
+### Step 5: Generate Results — Score Card
+
+Present the scored summary with score impact row:
+
+```
+## Score Card
+
+| Category                | Score | Weight | Weighted | Justification |
+|-------------------------|-------|--------|----------|---------------|
+| Content Quality         | X/10  | 25%    | X.XX     | [1-line why]  |
+| Structure & Formatting  | X/10  | 15%    | X.XX     | [1-line why]  |
+| Impact & Metrics        | X/10  | 20%    | X.XX     | [1-line why]  |
+| ATS Compatibility       | X/10  | 15%    | X.XX     | [1-line why]  |
+| Relevance               | X/10  | 15%    | X.XX     | [1-line why]  |
+| Professional Presentation | X/10 | 10%   | X.XX     | [1-line why]  |
+|-------------------------|-------|--------|----------|---------------|
+| **Composite Score**     |       |        | **X.XX** |               |
+
+Rating: [⭐ Exceptional / ✅ Strong / ⚠️ Adequate / 🔶 Needs Work / 🔴 Major Revision]
+
+**If all top 3 actions implemented:** X.XX → ~X.XX ([Target Rating])
+```
+
+---
+
+### Step 6: Optional HTML Dashboard
+
+Ask user:
+```
+Would you like to generate an interactive web dashboard for these results?
+1. Yes
+2. No
+```
+
+If yes:
+
+**Check for existing dashboard:**
+// turbo
+```bash
+ls docs/evaluation/*.html 2>/dev/null
+```
+
+If files exist:
+```
+Found existing evaluation dashboard(s):
+- [filename(s)]
+
+Would you like to:
+1. Replace the existing dashboard
+2. Create a new file (with timestamp suffix)
+```
+
+**Generate the dashboard:**
+
+Create an HTML file at `docs/evaluation/cv-evaluation.html` (or timestamped variant) with:
+
+**Design: Neo-Brutalism Theme**
+- Bold black borders (3-4px)
+- Vibrant accent colors (bright yellow, electric blue, hot pink)
+- Strong typography (large headings, monospace accents)
+- Offset box shadows for depth
+- Minimal gradients — flat, bold color blocks
+- Interactive hover states with transform effects
+
+**Dashboard sections:**
+1. **Header** — "CV Evaluation Report — Deep Dive" with date and target info
+2. **Positioning Diagnosis** — Highlighted one-liner at top
+3. **Career Arc** — Visual career timeline
+4. **Composite Score** — Large, prominent score display with rating badge + projected score
+5. **Category Breakdown** — Visual score bars with justification tooltips
+6. **Strengths & Improvements** — Expandable cards with evidence citations and rewrite examples
+7. **Contradictions** — Highlighted contradiction cards
+8. **Section Analysis** — Tabbed or accordion view per CV section (current role first, deepest)
+9. **Top 3 Actions** — Action cards with impact estimates
+10. **Job Match** (if applicable) — Keyword match visualization, gap table
+11. **Personal Touch Section** (at bottom):
+    - A motivational quote (rotate from a curated list, or select contextually)
+    - Generated by: [AI Agent Model Name]
+    - "Brought to you by [doctor500](https://github.com/doctor500) • [doctor500/cv](https://github.com/doctor500/cv)"
+
+**Requirements:** Single self-contained HTML file (inline CSS + JS), responsive, print-friendly.
+
+After generation, offer preview in browser or continue.
+
+---
+
+### Step 7: Iteration
+
+After presenting results:
+```
+What would you like to do next?
+1. Re-evaluate after making changes to index.md
+2. Deep-dive into a specific section
+3. Get rewrite suggestions for specific bullets
+4. Evaluate against a (different) job posting
+5. Switch to /evaluate-cv-quick for faster iteration
+6. Done
+```
+
+If option 1: Return to Step 2 with updated content.
+If option 2-4: Perform additional targeted analysis.
+If option 5: Run the quick workflow.
+
+---
+
+## Example Output (abbreviated)
+
+> **Positioning Diagnosis:** Your CV reads as a **strong 2023-era DevOps engineer**, but not as a **2026 infrastructure engineer leveraging AI**.
+
+> **Career Arc:** Helpdesk → Sysadmin → DevOps → [desired: AI-Infra]. Progression visible but not articulated.
+
+> **🔴 High Priority:** Profile Summary says "passion for automation" but omits AI/ML despite Agentic AI goal.
+> → Rewrite: "Infrastructure engineer with 6+ years building cloud-native platforms, now applying AI agents to automate operational workflows."
+> → Impact: Est. +1.0 to +1.5
+
+> **Top 3 Actions:**
+> | # | Action | Est. Impact |
+> |---|--------|-------------|
+> | 1 | Reposition summary | +1.0-1.5 |
+> | 2 | Add AI project | +0.5-1.0 |
+> | 3 | Quantify current role | +0.5 |
+> Combined: 6.85 → 8.5-9.0 (✅ Strong → ⭐ Exceptional)
+
+---
+
+## Error Handling
+
+- **Job URL unreachable:** Fallback chain (curl → browser → paste)
+- **Section not found in index.md:** Notify user, list available sections
+- **Empty CV:** Suggest using `/build-cv-wizard` workflow first
+- **Dashboard generation fails:** Fall back to markdown-only output
+- **Previous dashboard exists:** Always ask before overwriting
+- **Insight standard missing:** Self-check before presenting (Step 4 self-check)
+
+---
+
+_This is the comprehensive evaluation workflow with 10 mandatory insight quality standards. For lightweight, fast iteration, use `/evaluate-cv-quick`._

--- a/.agent/workflows/evaluate-cv-quick.md
+++ b/.agent/workflows/evaluate-cv-quick.md
@@ -1,10 +1,22 @@
 ---
-description: Evaluate and critique CV with scoring framework and optional web dashboard
+description: Quick CV evaluation with scoring framework (lightweight, ~2K-4K output tokens)
 ---
 
-# CV Evaluation Workflow
+# CV Evaluation — Quick
 
-**Purpose:** Provide fair critique, actionable suggestions, and scored evaluation for the CV in `index.md`. Optionally generate an interactive HTML dashboard to visualize results.
+**Purpose:** Fast, structured critique of the CV in `index.md` with scored evaluation and optional HTML dashboard. Lightweight version optimized for iteration cycles.
+
+> [!TIP]
+> **When to use Quick vs Deep Dive:**
+>
+> | Aspect | Quick (`/evaluate-cv-quick`) | Deep Dive (`/evaluate-cv-deepdive`) |
+> |--------|-----|-----------|
+> | Output tokens | ~2K-4K | ~8K-15K |
+> | Insight patterns | Best-effort | 10/10 mandatory |
+> | Evidence citations | Optional | Mandatory (every claim) |
+> | Rewrite examples | Optional | Mandatory (every suggestion) |
+> | Specificity | ~20-40% | ~80-95% |
+> | Best for | Quick checks, iteration cycles | Comprehensive review, major revisions |
 
 ## Important Notes
 - **Evaluation target:** Evaluates content in `index.md` (single source of truth)
@@ -72,6 +84,7 @@ Evaluation scope:
 - Target: [Entire CV / Specific section(s)]
 - Goal: [General review / Job-targeted / etc.]
 - Job target: [Job title at Company / None]
+- Mode: Quick (lightweight evaluation)
 
 Proceeding with evaluation...
 ```
@@ -265,11 +278,13 @@ What would you like to do next?
 2. Deep-dive into a specific section
 3. Get rewrite suggestions for specific bullets
 4. Evaluate against a (different) job posting
-5. Done
+5. Switch to /evaluate-cv-deepdive for comprehensive analysis
+6. Done
 ```
 
 If option 1: Return to Step 2 with updated content.
 If option 2-4: Perform additional targeted analysis.
+If option 5: Run the deep dive workflow.
 
 ---
 
@@ -289,49 +304,28 @@ If option 2-4: Perform additional targeted analysis.
     4. ATS optimization
     5. Specific concern
 
-👤: 2
+👤: 1
 
-🤖: Please provide the job posting URL or paste the description:
-
-👤: https://company.com/jobs/senior-devops-engineer
-
-🤖: Evaluating your CV against: Senior DevOps Engineer at Company...
+🤖: Evaluating your CV (Quick mode)...
 
     # CV Evaluation Results
 
     ## Overall Assessment
     Your CV presents a strong technical profile with excellent
-    quantified achievements. The infrastructure cost reduction
-    metrics are particularly impactful. However, some recent
-    role descriptions could be strengthened with more specific
-    outcomes.
+    quantified achievements...
 
     ## Score Card
     | Category                 | Score | Weight | Weighted |
     |--------------------------|-------|--------|----------|
     | Content Quality          | 8/10  | 25%    | 2.00     |
-    | Structure & Formatting   | 7/10  | 15%    | 1.05     |
-    | Impact & Metrics         | 8/10  | 20%    | 1.60     |
-    | ATS Compatibility        | 7/10  | 15%    | 1.05     |
-    | Relevance                | 9/10  | 15%    | 1.35     |
-    | Professional Presentation| 8/10  | 10%    | 0.80     |
-    | **Composite Score**      |       |        | **8.05** |
+    | ...                      | ...   | ...    | ...      |
+    | **Composite Score**      |       |        | **7.85** |
 
     Rating: ✅ Strong
 
-    [... detailed analysis follows ...]
-
-🤖: Would you like to generate an interactive web dashboard?
-    1. Yes
-    2. No
-
-👤: 1
-
-🤖: ✅ Dashboard generated at docs/evaluation/cv-evaluation.html
-    
-    You can customize the theme by editing CSS variables in the file.
-    
-    What would you like to do next?
+🤖: What would you like to do next?
+    ...
+    5. Switch to /evaluate-cv-deepdive for comprehensive analysis
 ```
 
 ---
@@ -346,4 +340,4 @@ If option 2-4: Perform additional targeted analysis.
 
 ---
 
-_This workflow evaluates content in `index.md`._
+_This is the lightweight evaluation workflow. For comprehensive, evidence-based evaluation with mandatory insight patterns, use `/evaluate-cv-deepdive`._

--- a/README.md
+++ b/README.md
@@ -452,7 +452,8 @@ This repository includes pre-built workflows in `.agent/workflows/` designed for
 | `/add-cv-section` | Add sections to `index.md` | Manual entry or LinkedIn fetch, auto-formatting, validation |
 | `/generate-template` | Create CSS templates | URL or description based, screen + print CSS, auto-testing |
 | `/build-cv-wizard` | Build CV from data sources | Multi-source gathering, 3-tier URL fallback, render testing |
-| `/evaluate-cv` | Score and critique CV | 6-category scoring, job-targeted mode, HTML dashboard |
+| `/evaluate-cv-quick` | Quick CV scoring & critique | 6-category scoring, ~2K-4K tokens, fast iteration cycles |
+| `/evaluate-cv-deepdive` | Comprehensive CV evaluation | 10 mandatory insight standards, evidence citations, rewrite examples, HTML dashboard |
 | `/git-branch-pr` | Git branch & PR management | Feature branches, PR automation, protected branch enforcement |
 
 ### Reference Documents
@@ -460,7 +461,8 @@ This repository includes pre-built workflows in `.agent/workflows/` designed for
 | File | Used By | Content |
 |------|---------|--------|
 | [`cv-construction-guide.md`](./.agent/references/cv-construction-guide.md) | `/build-cv-wizard` | Writing best practices, ATS tips |
-| [`cv-evaluation-framework.md`](./.agent/references/cv-evaluation-framework.md) | `/evaluate-cv` | 6-category scoring rubric |
+| [`cv-evaluation-framework.md`](./.agent/references/cv-evaluation-framework.md) | `/evaluate-cv-quick`, `/evaluate-cv-deepdive` | 6-category scoring rubric, 10 insight quality standards |
+| [`benchmark-testing-framework.md`](./.agent/references/benchmark-testing-framework.md) | `/evaluate-cv-deepdive` | Benchmark testing criteria and validation patterns |
 
 ### Technical Documentation
 

--- a/index.md
+++ b/index.md
@@ -160,7 +160,7 @@ Completed Business Intelligence minor, graduated in the 7th semester. Final GPA:
 [DevOps Engineering on AWS](https://1drv.ms/b/s!AgiuQdtA6DaqkRFlSnO8rKrDO8iQ?e=htxgE9), **from AWS**
 
 
-<div style="page-break-after: always;"></div>
+<!-- <div style="page-break-after: always;"></div> -->
 
 
 ### Latest Professional Projects

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: cv
 title: David Layardi
 ---
 # David Layardi
-Cloud Infrastructure, Automation, DevOps Engineer.
+Cloud Infrastructure, DevOps & Agentic AI Engineer.
 
 <div id="webaddress">
 <text>Tokyo, Japan</text>
@@ -20,7 +20,7 @@ David Layardi is an infrastructure and platform engineer with nearly a decade of
 
 Currently pioneering Agentic AI for infrastructure operations at Rakuten, he develops Claude Code plugins, AI Agent contexts, and autonomous analytical tooling that reduced cyber incident investigation from 24 hours to under 2 hours.
 
-He also builds open-source AI-governed infrastructure projects — including automated server provisioning with Kubernetes and AI Agent governance, and CV evaluation frameworks with scoring pipelines — combining deep Kubernetes, Terraform, and DevOps expertise with AI-powered operational workflows.
+He also builds open-source AI-governed infrastructure projects, including automated server provisioning with Kubernetes and AI Agent governance, and a CV evaluation framework with AI-powered scoring pipelines. These projects combine deep Kubernetes, Terraform, and DevOps expertise with agentic workflow orchestration for infrastructure-as-code operations.
 
 
 ## Technical Skills
@@ -59,10 +59,10 @@ Part of Rakuten OneCloud Initiative. Designing, maintaining, and automating larg
 
 __Infrastructure Engineer__, GovTech Procurement, Indonesia
 
-Government Technology (GovTech) Procurement is part of Telkom Indonesia (IDX: TLKM). Entrusted to maintain the operations of **600+** nation-scale government procurement apps, managing more than **20+** Kubernetes clusters that can have more than **70+** cost-effective worker nodes (spot instances).
-- Lead and execute infrastructure refactoring from the GCP Cloud Run workload to the GKE Kubernetes cluster. Decrease production costs by more than **90%** daily and save over **$150,000** monthly.
-- Transform the nation-level Mail Services from a monolithic VM to a scalable and cost-effective Kubernetes deployment. **Increase service scaling performance by six times**, making it more reliable.
-- Implement fully audited and approval-based access control for over **500** cloud resources in GovTech Procurement using Teleport.
+Government Technology (GovTech) Procurement is part of Telkom Indonesia (IDX: TLKM). Entrusted to maintain the operations of **600+** nation-scale government procurement apps, managing **20+** Kubernetes clusters with **70+** cost-effective worker nodes (spot instances).
+- Led and executed infrastructure refactoring from the GCP Cloud Run workload to the GKE Kubernetes cluster. Decreased production costs by more than **90%** daily and saved over **$150,000** monthly.
+- Transformed the nation-level Mail Services from a monolithic VM to a scalable and cost-effective Kubernetes deployment. **Increased service scaling performance by six times**, making it more reliable.
+- Implemented fully audited and approval-based access control for over **500** cloud resources in GovTech Procurement using Teleport.
 - Researched and implemented (POC) tooling to improve GovTech Procurement team productivity, such as Goldilocks, External Secrets Operator, Kafka on Kubernetes, Pomerium on GKE, and many more.
  
  
@@ -85,9 +85,9 @@ Maintained **100+** backend services in multi-cloud **Kubernetes** cluster, **Gi
 `Mar 2020 - Oct 2021`
 __Release Engineer__, Pegipegi, Indonesia
 
-Maintain the Jenkins pipeline and internal tools in the Kubernetes Cluster, which serves more than 100+ pipelines of backend services.
-- Transform **80%+** of redundant **Jenkins** pipeline files into a single standardized deployment pipeline. **Rebuilt the company-level pipeline** to scale up pipeline maintainability.
-- **Decreased up to 6x provisioning time** of pipeline supporting resources by migrating them to on top of the **Kubernetes** platform. Provide ready-to-use resources in less than a minute.
+Maintained the Jenkins pipeline and internal tools in the Kubernetes Cluster, serving **100+** backend service pipelines.
+- Transformed **80%+** of redundant **Jenkins** pipeline files into a single standardized deployment pipeline. **Rebuilt the company-level pipeline** to scale up pipeline maintainability.
+- **Decreased up to 6x provisioning time** of pipeline supporting resources by migrating them to on top of the **Kubernetes** platform. Provided ready-to-use resources in less than a minute.
 - **Decreased up to 85% of the pipeline initialization build time** of the backend repo (mono repo).
 - Scaled up backend pipeline capabilities to support **multi-cloud deployment** process.
 
@@ -97,10 +97,10 @@ __Data Center Staff__, Bina Nusantara - IT Division, Indonesia
 
 
 Worked closely with the Data Center & IT Infrastructure group to support Binus IT Operational Processes.
-- Pioneer of QR-based event registration system for Binus University, [<u>used on national-scale event</u>](https://binus.ac.id/2019/01/sarasehan-dialog-nasional-bersama-menteri-ristekdikti-republik-nasional/). Reduced manual checking time by 10x from minutes to QR scan and go in seconds. Develop using **PHP Laravel, SQL Server, and Windows Server 2016**. 
-- Create tools & scripts to automate data analyst reporting processes. Provided automation for student document reports to the university and government. Provide several tools/scripts using **PHP Laravel, Windows BAT Script, Pentaho, and SQL Server**.
-- Developed WiFi debugging tools to help the network-infra team when doing on-site WiFi connection troubleshooting. Simplified debug data gathering into a one-click process. Develop using **C#, PHP, and Windows Server 2016**.
-- Integrate **Windows AD** with physical facilities to enable access list automation. (access doors and building's WiFi for SSO). Speed up the batch manual registration process from a week to less than an hour automatic process. Develop using **Windows Active Directory API, PHP, Pentaho, and MikroTik**. 
+- Pioneer of QR-based event registration system for Binus University, [<u>used on national-scale event</u>](https://binus.ac.id/2019/01/sarasehan-dialog-nasional-bersama-menteri-ristekdikti-republik-nasional/). Reduced manual checking time by 10x from minutes to QR scan and go in seconds. Developed using **PHP Laravel, SQL Server, and Windows Server 2016**. 
+- Created tools & scripts to automate data analyst reporting processes. Provided automation for student document reports to the university and government. Developed using **PHP Laravel, Windows BAT Script, Pentaho, and SQL Server**.
+- Developed WiFi debugging tools to help the network-infra team when doing on-site WiFi connection troubleshooting. Simplified debug data gathering into a one-click process. Developed using **C#, PHP, and Windows Server 2016**.
+- Integrated **Windows AD** with physical facilities to enable access list automation (access doors and building's WiFi for SSO). Reduced the batch manual registration process from a week to less than an hour. Developed using **Windows Active Directory API, PHP, Pentaho, and MikroTik**. 
 
 <!-- <div style="page-break-after: always;"></div> -->
 
@@ -108,11 +108,7 @@ Worked closely with the Data Center & IT Infrastructure group to support Binus I
 `Feb 2016 - Jan 2019`
 __Freelance Web Developer__, Self Freelance, Indonesia
 
-
-Develop & Design web-based applications based on user requirements for several companies & organizations:
-- PT. Tri Jaya Samudera (February 2016). Design and develop a company profile using a non-database website (Static Website). Deployed on **Apache** server.
-- SMAN 7 Kota Bekasi (July 2016 - August 2016). Develop CMS with **PHP & MySQL** Based.
-- PT. Inspirasi Digital Elevasi (July 2018 - August 2018). Develop Invoice Management System for their client (PT. Royal ElSalam Universal) with web-based **PHP, MySQL, and Apache** server.
+Designed and delivered web-based applications for enterprise and education clients, including company profiles, CMS systems, and invoice management tools. Built with **PHP**, **MySQL**, and **Apache** stack.
 
 
 
@@ -124,7 +120,7 @@ __Bina Nusantara University, Jakarta__.
 
 Bachelor's degree, Major in Information Systems
 
-Take Business Intelligence minor, Graduate in the 7th semester. Final GPA: 3.8 of 4.0
+Completed Business Intelligence minor, graduated in the 7th semester. Final GPA: 3.8 of 4.0
 
 
 ## Activities
@@ -182,24 +178,24 @@ Built an open-source CV generation system using Jekyll and GitHub Actions, expan
 `May 2024 - Dec 2024`
 **SPSE Migration from Bare Metal to Government-certified Cloud**, GovTech Procurement
 
-Executed and supervised the automation of the SPSE migration process. Assessed, troubleshot, and designed infrastructure-level automation for moving more than **600** SPSE services to a Government-certified cloud, providing improved security and reliable infrastructure.
+Led the end-to-end automation of the SPSE migration process, moving more than **600** government procurement services from bare metal to a Government-certified cloud. Designed infrastructure-level automation for assessment, troubleshooting, and deployment, achieving improved security compliance and reliable infrastructure at scale.
 
 `Aug 2022 - Sep 2022`
 **Config & Secret Management for Selly.id using Vault Cluster**, Gojek - GoTo Financial (GTF)
 
-This implementation aims to make the Selly.id Engineers are more confident about every change they make in terms of configuration changes and every configuration change is stored historically. Implementation is done by creating a Vault Cluster and deploying the configuration values into the Kubernetes cluster natively.
+Implemented a Vault Cluster for Selly.id to provide 100% configuration change visibility and historical tracking. Deployed configuration values natively into the Kubernetes cluster, enabling engineers to make confident, auditable configuration changes.
 
 
 `Dec 2020 - Jul 2021`
 **Jenkins Shared Library (Research and Implementation)**, Pegipegi
 
-Make the build and release process more standardized by implementing the Jenkins Shared Library (JSL). Implementation is done by changing the distributed redundant Jenkinsfile into a centralized Pipeline that is placed in Version Control (git). This provides convenience in the process of debugging and monitoring because each process is equalized based on the type of presentation layer and also helps the process of standardizing the technology used.
+Standardized the build and release process by implementing the Jenkins Shared Library (JSL). Migrated distributed redundant Jenkinsfiles into a centralized, version-controlled pipeline, improving debugging, monitoring, and technology standardization across all services.
 
 
 `Apr 2019 - Dec 2019`
 **Automation for PDDikti Reporting**, Bina Nusantara - IT Division
 
-The primary goal is to create a data pipeline from operational data to reporting data. This project uses a combination of Pentaho Data Integration and in-house application development with PHP Laravel Framework. Responsible for project architecture and backend development. Optimizing semi-manual processes that can fail at any time into the process of pressing a button and the process can be seen when it's finished.
+Built a data pipeline from operational data to reporting data using Pentaho Data Integration and an in-house PHP Laravel application. Responsible for project architecture and backend development. Automated semi-manual reporting processes, transforming error-prone workflows into reliable one-click operations.
 
 
 ## Language

--- a/index.md
+++ b/index.md
@@ -16,17 +16,30 @@ Cloud Infrastructure, Automation, DevOps Engineer.
 
 ## Profile Summary
 
-David Layardi works in the field of infrastructure and platform engineering, focusing on building scalable, automated, and reliable cloud systems. With over six years of experience across multiple industries, he has driven infrastructure modernization projects that enhanced performance, reduced operational costs, and improved developer productivity.
+David Layardi is an infrastructure and platform engineer with nearly a decade of experience building scalable cloud systems across government (600+ apps), fintech (100+ services), and enterprise. He has delivered infrastructure cost reductions exceeding 90% and $150K monthly savings through Kubernetes migration, automation, and cloud refactoring on GCP and AWS.
 
-Specializing in Google Cloud Platform (GCP) and AWS, David has deep expertise in Kubernetes, Terraform, CI/CD automation, and cloud cost optimization. His work has led to significant improvements in reliability and efficiency, including infrastructure cost reductions of over 90% through strategic automation and refactoring.
+Currently pioneering Agentic AI for infrastructure operations at Rakuten, he develops Claude Code plugins, AI Agent contexts, and autonomous analytical tooling that reduced cyber incident investigation from 24 hours to under 2 hours.
 
-Beginning his career in software development from 2011, David’s curiosity and problem-solving mindset naturally evolved toward infrastructure and DevOps. He enjoys designing systems that empower developers, support business scalability, and simplify complex operations. Guided by continuous learning and a collaborative approach, he focuses on building platforms that enable teams to deliver securely, efficiently, and with confidence.
-
-
-### Technical Skill
+He also builds open-source AI-governed infrastructure projects — including automated server provisioning with Kubernetes and AI Agent governance, and CV evaluation frameworks with scoring pipelines — combining deep Kubernetes, Terraform, and DevOps expertise with AI-powered operational workflows.
 
 
-AWS (EC2, ECR, IAM, VPC, LB, Route53), GCP (CE, GKE, Cloud SQL, Cloud Logging, Cloud Monitoring, IAM, VPC, Artifact Registry, LB, Cloud DNS, Cloud Storage, Cloud Run, Secret Manager), Linux VM, Windows Server, Debian, CentOS, Docker, Kubernetes, Helm, Kustomize, MySQL, PostgreSQL, Git, Jenkins, GitLab CI, GitHub Actions, Python, Java (Groovy), Shell, Terraform, Nginx, OpenVPN, Teleport, Cloudflare, NewRelic, Datadog, Prometheus, Grafana
+## Technical Skills
+
+**Cloud Platforms:** AWS (EC2, ECR, IAM, VPC, LB, Route53), GCP (CE, GKE, Cloud SQL, Cloud Logging, Cloud Monitoring, IAM, VPC, Artifact Registry, LB, Cloud DNS, Cloud Storage, Cloud Run, Secret Manager)
+
+**Container & Orchestration:** Docker, Kubernetes, Helm, Kustomize, Harbor, JFrog Artifactory
+
+**CI/CD & Automation:** Jenkins, GitLab CI, GitHub Actions, ArgoCD
+
+**AI & Agentic Tools:** Claude Code, AI Agent Development, MCP (Model Context Protocol), Agentic Workflow Design, Prompt Engineering
+
+**Languages & Scripting:** Python, Go, Java (Groovy), Shell/Bash
+
+**Infrastructure as Code:** Terraform
+
+**Monitoring & Observability:** NewRelic, Datadog, Prometheus, Grafana
+
+**Networking & Security:** Nginx, OpenVPN, Teleport, Cloudflare
 
 
 ## Professional Experience
@@ -35,18 +48,22 @@ AWS (EC2, ECR, IAM, VPC, LB, Route53), GCP (CE, GKE, Cloud SQL, Cloud Logging, C
 
 __Software Engineer - CI/CD Platform__, Rakuten, Japan
 
-Part of Rakuten OneCloud Initiative. Designing, maintaining, and automating large-scale CI/CD infrastructure on Kubernetes to support enterprise-wide development. Responsible for CI/CD-as-a-Service, Container Registry (Harbor), and Artifact Registry (JFrog Artifactory). Focused on reliability, scalability, and developer enablement through automation, backend development (Go/Python), and platform modernization.
+Part of Rakuten OneCloud Initiative. Designing, maintaining, and automating large-scale CI/CD infrastructure on Kubernetes to support enterprise-wide development. Responsible for CI/CD-as-a-Service, Container Registry (Harbor), and Artifact Registry (JFrog Artifactory).
+- Developed Claude Code Plugin (Skills + Sub-Agent) to auto-generate compliance-ready operation documents, reducing document creation time by over **80%** with **100%** holistic compliance checks per cycle.
+- Reduced cyber incident investigation time from **24 hours to under 2 hours** by building AI-powered analysis pipelines for multi-department incident decision-making.
+- Designed and maintained CI/CD-as-a-Service platform on Kubernetes serving multiple business units, including Container Registry and Artifact Registry.
+- Built backend automation tooling in **Go** and **Python** for platform modernization and developer enablement.
 
 
 `Jan 2024 - Sep 2025`
 
 __Infrastructure Engineer__, GovTech Procurement, Indonesia
 
-Government Technology (GovTech) Procurement is part of Telkom Indonesia (IDX: TLKM). I'm entrusted to maintain the operations of **600+** nation-scale government procurement apps, managing more than **20+** Kubernetes clusters that can have more than **70+** cost-effective worker nodes (spot instances).
+Government Technology (GovTech) Procurement is part of Telkom Indonesia (IDX: TLKM). Entrusted to maintain the operations of **600+** nation-scale government procurement apps, managing more than **20+** Kubernetes clusters that can have more than **70+** cost-effective worker nodes (spot instances).
 - Lead and execute infrastructure refactoring from the GCP Cloud Run workload to the GKE Kubernetes cluster. Decrease production costs by more than **90%** daily and save over **$150,000** monthly.
 - Transform the nation-level Mail Services from a monolithic VM to a scalable and cost-effective Kubernetes deployment. **Increase service scaling performance by six times**, making it more reliable.
 - Implement fully audited and approval-based access control for over **500** cloud resources in GovTech Procurement using Teleport.
-- Research and implement (POC) independently or in groups for tooling to improve GovTech Procurement mankind productivity, such as Goldilocks, External Secrets Operator, Kafka on Kubernetes, Pomerium on GKE, and many more.
+- Researched and implemented (POC) tooling to improve GovTech Procurement team productivity, such as Goldilocks, External Secrets Operator, Kafka on Kubernetes, Pomerium on GKE, and many more.
  
  
 <!-- <div style="page-break-after: always;"></div> -->
@@ -59,8 +76,8 @@ __DevOps Engineer__, Gojek - GoTo Financial (GTF), Indonesia
 Maintained **100+** backend services in multi-cloud **Kubernetes** cluster, **Gitlab CI** pipeline & runners to fulfill 24/7 business needs.
 - **Decreased AWS infra cost** for application development by **up to 50% hourly** by planning and executing **cloud cost-saving** activities based on resource utilization metrics.
 - **Provided 100% configuration visibility** to prevent backend misconfiguration cases by improving GTF product-level (Selly Keyboard) backend release processes using open-source secret and configuration management (**Vault**). 
-- Create **transformation for 400+** existing production-level **AWS** resources to Code-based configuration and integrate them with cloud cost analysis.
-- Optimize the **GCP Cloud SQL** Migration Process from **2 Hours to 15 minutes** by implementing the CDC mechanism using **GCP DMS**
+- Created **transformation for 400+** existing production-level **AWS** resources to Code-based configuration and integrated them with cloud cost analysis.
+- Optimized the **GCP Cloud SQL** Migration Process from **2 Hours to 15 minutes** by implementing the CDC mechanism using **GCP DMS**.
 
 
 
@@ -72,14 +89,14 @@ Maintain the Jenkins pipeline and internal tools in the Kubernetes Cluster, whic
 - Transform **80%+** of redundant **Jenkins** pipeline files into a single standardized deployment pipeline. **Rebuilt the company-level pipeline** to scale up pipeline maintainability.
 - **Decreased up to 6x provisioning time** of pipeline supporting resources by migrating them to on top of the **Kubernetes** platform. Provide ready-to-use resources in less than a minute.
 - **Decreased up to 85% of the pipeline initialization build time** of the backend repo (mono repo).
-- Scalled up backend pipeline capabilities to support **multi-cloud deployment** process.
+- Scaled up backend pipeline capabilities to support **multi-cloud deployment** process.
 
 
 `Mar 2018 - Feb 2020`
 __Data Center Staff__, Bina Nusantara - IT Division, Indonesia
 
 
-Work closely with the Data Center & IT Infrastructure group to Help Binus IT Operational Processes.
+Worked closely with the Data Center & IT Infrastructure group to support Binus IT Operational Processes.
 - Pioneer of QR-based event registration system for Binus University, [<u>used on national-scale event</u>](https://binus.ac.id/2019/01/sarasehan-dialog-nasional-bersama-menteri-ristekdikti-republik-nasional/). Reduced manual checking time by 10x from minutes to QR scan and go in seconds. Develop using **PHP Laravel, SQL Server, and Windows Server 2016**. 
 - Create tools & scripts to automate data analyst reporting processes. Provided automation for student document reports to the university and government. Provide several tools/scripts using **PHP Laravel, Windows BAT Script, Pentaho, and SQL Server**.
 - Developed WiFi debugging tools to help the network-infra team when doing on-site WiFi connection troubleshooting. Simplified debug data gathering into a one-click process. Develop using **C#, PHP, and Windows Server 2016**.
@@ -115,22 +132,24 @@ Take Business Intelligence minor, Graduate in the 7th semester. Final GPA: 3.8 o
 `Apr 2024`
 [**Accessing GCP Secret Manager from GKE Cluster using Murmur**](https://davidlayardi.medium.com/accessing-gcp-secret-manager-from-gke-cluster-using-murmur-34c679f25333)
 
-- Reach 400+ Visitor (per 2025/12/21) under Self Publication
+- Reach 450+ Visitor (per 2026/02/14) under Self Publication
 
 `Apr 2023`
 [**How Cloudflare Zero Trust & VS Code Tunnels Reducing My Back Pain**](https://medium.com/@davidlayardi/how-cloudflare-trust-zero-vs-code-tunnels-reducing-my-back-pain-67c38c506a28)
 
-- Reach 3600+ Visitor (per 2025/12/21) under Self Publication
+- Reach 3800+ Visitor (per 2026/02/14) under Self Publication
 
 `Aug 2021`
 [**Automate Export From Jenkins API Job List to Google Sheets Using Google Apps Script**](https://medium.com/geekculture/automate-export-from-jenkins-api-job-list-to-google-sheets-using-google-apps-script-2eef44008bdc)
 
-- Reach 2200+ Visitor (per 2025/12/21) under Geek Culture publication
+- Reach 2200+ Visitor (per 2026/02/14) under Geek Culture publication
 
 `Jul 2021`
 [**Easy Deploy SonarQube on Kubernetes with YAML configuration**](https://medium.com/codex/easy-deploy-sonarqube-on-kubernetes-with-yaml-configuration-27f5adc8de90)
 
-- Reach 20000+ Visitor (per 2025/12/21) under CodeX publication
+- Reach 20000+ Visitor (per 2026/02/14) under CodeX publication
+
+
 
 
 ### Training & Certifications
@@ -150,10 +169,20 @@ Take Business Intelligence minor, Graduate in the 7th semester. Final GPA: 3.8 o
 
 ### Latest Professional Projects
 
+`Oct 2025 - Present`
+**Compliance Document Automation Plugin (Claude Code)**, Rakuten
+
+Developed Claude Code Plugin consisting of Skills and Sub-Agent to auto-generate compliance-ready operation documents for CI/CD operations. Reduced document creation time by over **80%**, with **100%** holistic compliance checks on every document creation and update cycle. Previously a fully manual process requiring cross-team coordination.
+
+`2024 - Present`
+**Open Source CV with AI-Powered Evaluation Framework**, Personal — [github.com/doctor500/cv](https://github.com/doctor500/cv)
+
+Built an open-source CV generation system using Jekyll and GitHub Actions, expanded with AI Agent capabilities: automated CV evaluation workflows (quick + deep dive), a scoring framework across **6** categories and **10** quality standards, and AI-powered content improvement pipelines. Integrated Claude Code, MCP, and agentic workflow orchestration for infrastructure-as-code operations.
+
 `May 2024 - Dec 2024`
 **SPSE Migration from Bare Metal to Government-certified Cloud**, GovTech Procurement
 
-Execute and supervise the Automation process of the SPSE migration process. Assess, troubleshoot, and design for implementing automation at the infrastructure level. We're currently moving more than 600 SPSE services to a Government-certified cloud. Provide them with better security and reliable infrastructure.
+Executed and supervised the automation of the SPSE migration process. Assessed, troubleshot, and designed infrastructure-level automation for moving more than **600** SPSE services to a Government-certified cloud, providing improved security and reliable infrastructure.
 
 `Aug 2022 - Sep 2022`
 **Config & Secret Management for Selly.id using Vault Cluster**, Gojek - GoTo Financial (GTF)
@@ -177,6 +206,7 @@ The primary goal is to create a data pipeline from operational data to reporting
 __Indonesian__ - Native proficiency
 
 __English__ - Business level proficiency
+
 
 
 <!-- ### Footer


### PR DESCRIPTION
## Summary

Sync `page-release` → `main` to bring README updates and recent CV content changes to the main branch.

### Included changes
- README: split `/evaluate-cv` into `/evaluate-cv-quick` + `/evaluate-cv-deepdive`
- README: added `benchmark-testing-framework.md` reference
- All recent CV content improvements from previous PRs