### PR TITLE
docs: fix branch architecture — dummy CV for main, sync rules for workflows

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,209 +1,132 @@
 ---
 layout: cv
-title: David Layardi
+title: CV - Alex Johnson
 ---
-# David Layardi
-Cloud Infrastructure, DevOps & Agentic AI Engineer.
+
+<!-- ℹ️ This is an EXAMPLE CV to demonstrate the markdown-cv formatting patterns.
+     Replace all content below with your own information.
+     See .agent/references/cv-construction-guide.md for writing best practices. -->
+
+# Alex Johnson
 
 <div id="webaddress">
-<text>Tokyo, Japan</text>
-| <a href="mailto:david@layardi.com">david@layardi.com</a>
-| <a href="https://github.com/doctor500">github.com/doctor500</a>
-| <a href="https://www.linkedin.com/in/david-lay/">linkedin.com/in/david-lay</a>
-| <a href="https://medium.com/@davidlayardi">medium.com/@davidlayardi</a>
+<a href="mailto:alex.johnson@example.com">alex.johnson@example.com</a>
+| <a href="https://linkedin.com/in/alexjohnson">LinkedIn</a>
+| <a href="https://github.com/alexjohnson">GitHub</a>
+| San Francisco, CA
 </div>
-
 
 ## Profile Summary
 
-David Layardi is an infrastructure and platform engineer with nearly a decade of experience building scalable cloud systems across government (600+ apps), fintech (100+ services), and enterprise. He has delivered infrastructure cost reductions exceeding 90% and $150K monthly savings through Kubernetes migration, automation, and cloud refactoring on GCP and AWS.
+Senior Cloud and DevOps Engineer with over **8 years** of experience designing, deploying, and maintaining scalable cloud infrastructure across **AWS** and **GCP** environments. Proven track record of reducing infrastructure costs by **40%** while improving system reliability to **99.95%** uptime through infrastructure-as-code practices and CI/CD automation.
 
-Currently pioneering Agentic AI for infrastructure operations at Rakuten, he develops Claude Code plugins, AI Agent contexts, and autonomous analytical tooling that reduced cyber incident investigation from 24 hours to under 2 hours.
+Specializes in container orchestration with **Kubernetes**, infrastructure automation with **Terraform**, and building developer-friendly platform tooling. Led cloud migration initiatives serving **200+** microservices and **50M+** monthly active users.
 
-He also builds open-source AI-governed infrastructure projects, including automated server provisioning with Kubernetes and AI Agent governance, and a CV evaluation framework with AI-powered scoring pipelines. These projects combine deep Kubernetes, Terraform, and DevOps expertise with agentic workflow orchestration for infrastructure-as-code operations.
-
+Passionate about bridging the gap between development and operations through automation, observability, and self-service platforms. Active open-source contributor and technical blogger.
 
 ## Technical Skills
 
-**Cloud Platforms:** AWS (EC2, ECR, IAM, VPC, LB, Route53), GCP (CE, GKE, Cloud SQL, Cloud Logging, Cloud Monitoring, IAM, VPC, Artifact Registry, LB, Cloud DNS, Cloud Storage, Cloud Run, Secret Manager)
+**Cloud Platforms:** AWS (EC2, EKS, S3, IAM, VPC, Route53, CloudFront), GCP (GKE, Cloud SQL, Cloud Run, IAM, Cloud Storage)
 
-**Container & Orchestration:** Docker, Kubernetes, Helm, Kustomize, Harbor, JFrog Artifactory
+**Container & Orchestration:** Docker, Kubernetes, Helm, Kustomize, Harbor
 
-**CI/CD & Automation:** Jenkins, GitLab CI, GitHub Actions, ArgoCD
+**CI/CD & Automation:** Jenkins, GitHub Actions, ArgoCD, Flux
 
-**AI & Agentic Tools:** Claude Code, AI Agent Development, MCP (Model Context Protocol), Agentic Workflow Design, Prompt Engineering
+**Languages & Scripting:** Python, Go, Shell/Bash, TypeScript
 
-**Languages & Scripting:** Python, Go, Java (Groovy), Shell/Bash
+**Infrastructure as Code:** Terraform, Pulumi, CloudFormation
 
-**Infrastructure as Code:** Terraform
+**Monitoring & Observability:** Prometheus, Grafana, Datadog, PagerDuty
 
-**Monitoring & Observability:** NewRelic, Datadog, Prometheus, Grafana
+**Networking & Security:** Nginx, Istio, Cloudflare, HashiCorp Vault
 
-**Networking & Security:** Nginx, OpenVPN, Teleport, Cloudflare
+**Databases:** PostgreSQL, MySQL, Redis, MongoDB
 
 
 ## Professional Experience
 
-`Oct 2025 - Present`
+`Jan 2022 - Now`
+__Senior Cloud Engineer__, TechCorp Inc.
 
-__Software Engineer - CI/CD Platform__, Rakuten, Japan
+Lead cloud infrastructure team of **5 engineers** managing multi-cloud environments across AWS and GCP, serving **200+** microservices with **99.95%** uptime SLA.
 
-Part of Rakuten OneCloud Initiative. Designing, maintaining, and automating large-scale CI/CD infrastructure on Kubernetes to support enterprise-wide development. Responsible for CI/CD-as-a-Service, Container Registry (Harbor), and Artifact Registry (JFrog Artifactory).
-- Developed Claude Code Plugin (Skills + Sub-Agent) to auto-generate compliance-ready operation documents, reducing document creation time by over **80%** with **100%** holistic compliance checks per cycle.
-- Reduced cyber incident investigation time from **24 hours to under 2 hours** by building AI-powered analysis pipelines for multi-department incident decision-making.
-- Designed and maintained CI/CD-as-a-Service platform on Kubernetes serving multiple business units, including Container Registry and Artifact Registry.
-- Built backend automation tooling in **Go** and **Python** for platform modernization and developer enablement.
+- Architected and deployed **Kubernetes-based platform** serving **50M+ monthly users**, reducing deployment time from **2 hours to 15 minutes** through GitOps workflows with ArgoCD
+- Reduced monthly cloud spend by **$85,000 (40%)** through right-sizing, spot instance adoption, and automated resource scheduling
+- Built internal developer platform (IDP) enabling **120+ developers** to self-service infrastructure provisioning, cutting ticket volume by **70%**
+- Implemented zero-trust security model with **HashiCorp Vault** and service mesh, achieving SOC 2 Type II compliance
 
+`Mar 2019 - Dec 2021`
+__DevOps Engineer__, CloudScale Solutions
 
-`Jan 2024 - Sep 2025`
+Managed CI/CD pipelines and infrastructure for a B2B SaaS platform processing **$2B+** in annual transactions.
 
-__Infrastructure Engineer__, GovTech Procurement, Indonesia
+- Migrated **85 services** from EC2 to EKS, reducing infrastructure costs by **35%** and improving deployment frequency from weekly to **multiple daily releases**
+- Designed and implemented **Terraform modules** standardizing infrastructure across **3 AWS regions**, reducing provisioning errors by **90%**
+- Built automated disaster recovery system achieving **RPO < 5 minutes** and **RTO < 30 minutes**, tested quarterly
 
-Government Technology (GovTech) Procurement is part of Telkom Indonesia (IDX: TLKM). Entrusted to maintain the operations of **600+** nation-scale government procurement apps, managing **20+** Kubernetes clusters with **70+** cost-effective worker nodes (spot instances).
-- Led and executed infrastructure refactoring from the GCP Cloud Run workload to the GKE Kubernetes cluster. Decreased production costs by more than **90%** daily and saved over **$150,000** monthly.
-- Transformed the nation-level Mail Services from a monolithic VM to a scalable and cost-effective Kubernetes deployment. **Increased service scaling performance by six times**, making it more reliable.
-- Implemented fully audited and approval-based access control for over **500** cloud resources in GovTech Procurement using Teleport.
-- Researched and implemented (POC) tooling to improve GovTech Procurement team productivity, such as Goldilocks, External Secrets Operator, Kafka on Kubernetes, Pomerium on GKE, and many more.
- 
- 
-<!-- <div style="page-break-after: always;"></div> -->
+<div style="page-break-after: always;"></div>
 
+`Jun 2017 - Feb 2019`
+__Systems Engineer__, DataFlow Corp
 
-`Nov 2021 - Dec 2023`
+Maintained on-premises and hybrid cloud infrastructure supporting enterprise data analytics platform.
 
-__DevOps Engineer__, Gojek - GoTo Financial (GTF), Indonesia
-
-Maintained **100+** backend services in multi-cloud **Kubernetes** cluster, **Gitlab CI** pipeline & runners to fulfill 24/7 business needs.
-- **Decreased AWS infra cost** for application development by **up to 50% hourly** by planning and executing **cloud cost-saving** activities based on resource utilization metrics.
-- **Provided 100% configuration visibility** to prevent backend misconfiguration cases by improving GTF product-level (Selly Keyboard) backend release processes using open-source secret and configuration management (**Vault**). 
-- Created **transformation for 400+** existing production-level **AWS** resources to Code-based configuration and integrated them with cloud cost analysis.
-- Optimized the **GCP Cloud SQL** Migration Process from **2 Hours to 15 minutes** by implementing the CDC mechanism using **GCP DMS**.
+- Automated server provisioning with **Ansible**, reducing setup time from **3 days to 2 hours** for new environments
+- Implemented centralized logging with **ELK stack**, processing **500GB+ daily** logs across **150+ servers**
 
 
+## Latest Professional Projects
 
+`2024`
+__Cloud Cost Optimizer__
 
-`Mar 2020 - Oct 2021`
-__Release Engineer__, Pegipegi, Indonesia
+Open-source tool for automated cloud cost analysis and optimization recommendations across AWS and GCP.
 
-Maintained the Jenkins pipeline and internal tools in the Kubernetes Cluster, serving **100+** backend service pipelines.
-- Transformed **80%+** of redundant **Jenkins** pipeline files into a single standardized deployment pipeline. **Rebuilt the company-level pipeline** to scale up pipeline maintainability.
-- **Decreased up to 6x provisioning time** of pipeline supporting resources by migrating them to on top of the **Kubernetes** platform. Provided ready-to-use resources in less than a minute.
-- **Decreased up to 85% of the pipeline initialization build time** of the backend repo (mono repo).
-- Scaled up backend pipeline capabilities to support **multi-cloud deployment** process.
+- Built with **Go** and **Python**, analyzes resource utilization patterns and suggests right-sizing
+- Achieved **$200K+ cumulative savings** across **15 organizations** using the tool
+- **500+ GitHub stars**, featured in KubeCon 2024 lightning talks
 
+`2023`
+__Platform Blueprint__
 
-`Mar 2018 - Feb 2020`
-__Data Center Staff__, Bina Nusantara - IT Division, Indonesia
+Self-service infrastructure platform template for bootstrapping Kubernetes-based developer platforms.
 
-
-Worked closely with the Data Center & IT Infrastructure group to support Binus IT Operational Processes.
-- Pioneer of QR-based event registration system for Binus University, [<u>used on national-scale event</u>](https://binus.ac.id/2019/01/sarasehan-dialog-nasional-bersama-menteri-ristekdikti-republik-nasional/). Reduced manual checking time by 10x from minutes to QR scan and go in seconds. Developed using **PHP Laravel, SQL Server, and Windows Server 2016**. 
-- Created tools & scripts to automate data analyst reporting processes. Provided automation for student document reports to the university and government. Developed using **PHP Laravel, Windows BAT Script, Pentaho, and SQL Server**.
-- Developed WiFi debugging tools to help the network-infra team when doing on-site WiFi connection troubleshooting. Simplified debug data gathering into a one-click process. Developed using **C#, PHP, and Windows Server 2016**.
-- Integrated **Windows AD** with physical facilities to enable access list automation (access doors and building's WiFi for SSO). Reduced the batch manual registration process from a week to less than an hour. Developed using **Windows Active Directory API, PHP, Pentaho, and MikroTik**. 
-
-<!-- <div style="page-break-after: always;"></div> -->
-
-
-`Feb 2016 - Jan 2019`
-__Freelance Web Developer__, Self Freelance, Indonesia
-
-Designed and delivered web-based applications for enterprise and education clients, including company profiles, CMS systems, and invoice management tools. Built with **PHP**, **MySQL**, and **Apache** stack.
-
-
+- Terraform modules + Helm charts for **one-command** platform deployment
+- Integrated **ArgoCD**, **Prometheus**, **Grafana**, and **Vault** out of the box
+- Used by **30+ teams** internally, open-sourced with comprehensive documentation
 
 
 ## Education
 
-`2016 - 2020`
-__Bina Nusantara University, Jakarta__. 
+`2013 - 2017`
+__University of California, Berkeley__
 
-Bachelor's degree, Major in Information Systems
-
-Completed Business Intelligence minor, graduated in the 7th semester. Final GPA: 3.8 of 4.0
+Bachelor of Science in Computer Science, GPA: **3.7** of 4.0
 
 
-## Activities
-### Medium Articles
-`Apr 2024`
-[**Accessing GCP Secret Manager from GKE Cluster using Murmur**](https://davidlayardi.medium.com/accessing-gcp-secret-manager-from-gke-cluster-using-murmur-34c679f25333)
+## Certifications & Activities
 
-- Reach 450+ Visitor (per 2026/02/14) under Self Publication
+`Feb 2024`
+[**AWS Solutions Architect Professional**](https://example.com/cert/aws-sap)
 
-`Apr 2023`
-[**How Cloudflare Zero Trust & VS Code Tunnels Reducing My Back Pain**](https://medium.com/@davidlayardi/how-cloudflare-trust-zero-vs-code-tunnels-reducing-my-back-pain-67c38c506a28)
+Credential ID: ABC123456
 
-- Reach 3800+ Visitor (per 2026/02/14) under Self Publication
+`Aug 2023`
+[**Certified Kubernetes Administrator (CKA)**](https://example.com/cert/cka)
 
-`Aug 2021`
-[**Automate Export From Jenkins API Job List to Google Sheets Using Google Apps Script**](https://medium.com/geekculture/automate-export-from-jenkins-api-job-list-to-google-sheets-using-google-apps-script-2eef44008bdc)
+Credential ID: CKA-2023-12345
 
-- Reach 2200+ Visitor (per 2026/02/14) under Geek Culture publication
+`Mar 2023`
+[**Building Resilient Cloud Infrastructure: Lessons from Production**](https://medium.com/@alexjohnson/resilient-cloud)
 
-`Jul 2021`
-[**Easy Deploy SonarQube on Kubernetes with YAML configuration**](https://medium.com/codex/easy-deploy-sonarqube-on-kubernetes-with-yaml-configuration-27f5adc8de90)
+Published on Medium — **15,000+ views**, **500+ claps**
 
-- Reach 20000+ Visitor (per 2026/02/14) under CodeX publication
+`Nov 2022`
+[**GCP Professional Cloud Architect**](https://example.com/cert/gcp-pca)
 
-
-
-
-### Training & Certifications
-
-`Jan 2023`
-[Associate Cloud Engineer](https://1drv.ms/b/c/aa36e840db41ae08/IQAIrkHbQOg2IICqawoAAAAAAXgi4mP106MEfaVJgA1The4?e=dA2Xfe), **from GCP**
-
-`Sep 2022`
-[Google Cloud Fundamentals: Core Infrastructure](https://www.coursera.org/account/accomplishments/verify/B2V6L4ZSGNUH), **from Coursera**
-
-`Mar 2021`
-[DevOps Engineering on AWS](https://1drv.ms/b/s!AgiuQdtA6DaqkRFlSnO8rKrDO8iQ?e=htxgE9), **from AWS**
-
-
-<!-- <div style="page-break-after: always;"></div> -->
-
-
-### Latest Professional Projects
-
-`Oct 2025 - Present`
-**Compliance Document Automation Plugin (Claude Code)**, Rakuten
-
-Developed Claude Code Plugin consisting of Skills and Sub-Agent to auto-generate compliance-ready operation documents for CI/CD operations. Reduced document creation time by over **80%**, with **100%** holistic compliance checks on every document creation and update cycle. Previously a fully manual process requiring cross-team coordination.
-
-`2024 - Present`
-**Open Source CV with AI-Powered Evaluation Framework**, Personal — [github.com/doctor500/cv](https://github.com/doctor500/cv)
-
-Built an open-source CV generation system using Jekyll and GitHub Actions, expanded with AI Agent capabilities: automated CV evaluation workflows (quick + deep dive), a scoring framework across **6** categories and **10** quality standards, and AI-powered content improvement pipelines. Integrated Claude Code, MCP, and agentic workflow orchestration for infrastructure-as-code operations.
-
-`May 2024 - Dec 2024`
-**SPSE Migration from Bare Metal to Government-certified Cloud**, GovTech Procurement
-
-Led the end-to-end automation of the SPSE migration process, moving more than **600** government procurement services from bare metal to a Government-certified cloud. Designed infrastructure-level automation for assessment, troubleshooting, and deployment, achieving improved security compliance and reliable infrastructure at scale.
-
-`Aug 2022 - Sep 2022`
-**Config & Secret Management for Selly.id using Vault Cluster**, Gojek - GoTo Financial (GTF)
-
-Implemented a Vault Cluster for Selly.id to provide 100% configuration change visibility and historical tracking. Deployed configuration values natively into the Kubernetes cluster, enabling engineers to make confident, auditable configuration changes.
-
-
-`Dec 2020 - Jul 2021`
-**Jenkins Shared Library (Research and Implementation)**, Pegipegi
-
-Standardized the build and release process by implementing the Jenkins Shared Library (JSL). Migrated distributed redundant Jenkinsfiles into a centralized, version-controlled pipeline, improving debugging, monitoring, and technology standardization across all services.
-
-
-`Apr 2019 - Dec 2019`
-**Automation for PDDikti Reporting**, Bina Nusantara - IT Division
-
-Built a data pipeline from operational data to reporting data using Pentaho Data Integration and an in-house PHP Laravel application. Responsible for project architecture and backend development. Automated semi-manual reporting processes, transforming error-prone workflows into reliable one-click operations.
+Credential ID: GCP-PCA-789
 
 
 ## Language
-__Indonesian__ - Native proficiency
 
-__English__ - Business level proficiency
-
-
-
-<!-- ### Footer
-Last updated: May 2025 -->
+English (Native), Spanish (Conversational)


### PR DESCRIPTION
## Summary

Fixes the branch architecture to prevent personal CV content from leaking to `main` (the upstream template branch for fork users).

### Root Cause
The previous deployment flow (`page-release → PR → main`) synced **all** files including `index.md`, which overwrote the template with personal data and created breaking merge conflicts for fork users.

### Changes

**`index.md` — Example CV:**
- Replaced personal CV with a professional dummy example ("Alex Johnson, Senior Cloud Engineer")
- Demonstrates all markdown formatting patterns (backtick dates, bold metrics, page breaks)
- Includes HTML comment guiding users to the construction guide

**`git-branch-pr.md` — Workflow:**
- Replaced "Deployment Flow" with "Branch Architecture" section with clear branch purposes
- Added Sync Rules table: which files to always/never/case-by-case sync
- Added Step 11: file-specific sync workflow using `git checkout page-release -- <files>`
- Added `index.md` safety check command
- Updated AI Agent Guidelines with sync safeguards and anti-patterns

### Impact
- Fork users will get a clean, usable example CV instead of personal data
- AI agents will follow the new sync rules and never blindly merge page-release → main